### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+- package-ecosystem: "gomod"
+  directory: "/e2e"
+  schedule:
+    interval: "daily"
+  commit-message:
+    prefix: "ci"
+    include: "scope"
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"
+  commit-message:
+    prefix: "ci"
+    include: "scope"


### PR DESCRIPTION
## Summary

Go dep updates should belong to `ci` type because they are not user-facing (i.e., only run in CI), so they shouldn't trigger a release.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.