### PR TITLE
chore: Add script and workflow for downloading dependency sources

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,6 +53,15 @@ jobs:
           path: ./src/lima/lima-and-qemu.macos*
           if-no-files-found: error
 
+      - name: Make and release source code of dependencies
+        run: make download-sources
+      - name: Upload MacOS build
+        uses: actions/upload-artifact@v3
+        with:
+          name: dependencies.sources-arm64
+          path: ./downloads/dependency-sources*
+          if-no-files-found: error
+
   macos-x86-build:
     runs-on: ['self-hosted', 'macos', 'amd64', '11.7']
     timeout-minutes: 60
@@ -94,6 +103,15 @@ jobs:
           path: ./src/lima/lima-and-qemu.macos*
           if-no-files-found: error
 
+      - name: Make and release source code of dependencies
+        run: make download-sources
+      - name: Upload MacOS build
+        uses: actions/upload-artifact@v3
+        with:
+          name: dependencies.sources-x86
+          path: ./downloads/dependency-sources*
+          if-no-files-found: error
+
   release:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -123,9 +141,20 @@ jobs:
         with:
           name: lima-and-qemu.macos-x86
           path: build
+
+      - name: Download MacOS ARM64 dependencies' sources
+        uses: actions/download-artifact@v3
+        with:
+          name: dependencies.sources-arm64
+          path: build
+
+      - name: Download MacOS x86_64 dependencies' sources
+        uses: actions/download-artifact@v3
+        with:
+          name: dependencies.sources-x86
+          path: build
+
       - name: "Upload to S3"
         run: |
-          aws s3 cp ./build/ s3://${{ secrets.DEPENDENCY_BUCKET_NAME }}/aarch64/ --recursive --exclude "*" --include "lima-and-qemu.macos-aarch64*"
-          aws s3 cp ./build/ s3://${{ secrets.DEPENDENCY_BUCKET_NAME }}/x86-64/ --recursive --exclude "*" --include "lima-and-qemu.macos-x86_64*"
-    
-
+          aws s3 cp ./build/ s3://${{ secrets.DEPENDENCY_BUCKET_NAME }}/aarch64/ --recursive --exclude "*" --include "lima-and-qemu.macos-aarch64*" --include "dependencies-sources-aarch64*"
+          aws s3 cp ./build/ s3://${{ secrets.DEPENDENCY_BUCKET_NAME }}/x86-64/ --recursive --exclude "*" --include "lima-and-qemu.macos-x86_64*" --include "dependencies-sources-x86_64*"

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,11 @@ install-deps: lima
 	mv src/lima/lima-and-qemu.tar.gz src/lima/lima-and-qemu.macos-${LIMA_ARCH}.${BUILD_TS}.tar.gz
 	sha512sum src/lima/lima-and-qemu.macos-${LIMA_ARCH}.${BUILD_TS}.tar.gz | cut -d " " -f 1  > src/lima/lima-and-qemu.macos-${LIMA_ARCH}.${BUILD_TS}.tar.gz.sha512sum
 
+.PHONY: download-sources
+download-sources: install-deps
+	./bin/download-sources.pl
+	mv ./downloads/dependency-sources.tar.gz ./downloads/dependency-sources-${LIMA_ARCH}.${BUILD_TS}.tar.gz
+
 .PHONY: os
 os: download
 	mkdir -p $(OUTDIR)/os

--- a/bin/download-sources.pl
+++ b/bin/download-sources.pl
@@ -1,0 +1,43 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use FindBin qw();
+use JSON qw( decode_json );
+
+my $repo_root = join('/', dirname($FindBin::Bin));
+my $dist = "dependency-sources";
+
+system("rm -rf /tmp/$dist");
+
+# Stage files in /tmp/$dist.
+system("mkdir -p /tmp/$dist");
+
+system("mkdir -p $repo_root/downloads");
+my $dependencies = `brew deps --full-name qemu`;
+my @arr = split('\n', $dependencies);
+
+# Add qemu itself. 
+push(@arr, "qemu");
+for my $dependency (@arr) {
+    print "Downloading sources for: $dependency \n";
+    # download source code
+    download_deps($dependency);
+}
+
+sub download_deps {
+    my $dep = shift;
+    # parse download url from package
+    my $dep_info = `brew info --json $dep`;
+    my @decoded_dep_info = @{decode_json($dep_info)};
+    my $source_url = $decoded_dep_info[0]->{'urls'}{'stable'}{'url'};
+    print "Source url: $source_url\n";
+
+    # -L flag to allow redirections
+    system("cd /tmp/$dist && (curl -LO $source_url; cd -;)");
+    system("tar czfv $repo_root/downloads/dependency-sources.tar.gz -C /tmp/dependency-sources/ .");
+}
+
+sub dirname {
+    shift =~ s|/[^/]+$||r;
+}


### PR DESCRIPTION
Signed-off-by: Vishwas Siravara <siravara@amazon.com>

Issue #, if available:
N/A
*Description of changes:*
GNU GPL [licence](https://www.gnu.org/licenses/gpl-3.0.en.html) requires us to distribute source code and license files along with the binary release. This process is currently managed manually. This change uploads the external sources using a github workflow. 

Changes:
1. Create tar ball which contains all the sources and licenses of finch dependencies and uploads to an s3 bucket for signing. 

*Testing done:*
Yes, locally. 

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.