### PR TITLE
chore: Change amd64 runner to 10.15 OS version for build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,7 +54,7 @@ jobs:
           if-no-files-found: error
 
   macos-x86-build:
-    runs-on: ['self-hosted', 'macos', 'amd64', '11.7']
+    runs-on: ['self-hosted', 'macos', 'amd64', '10.15']
     timeout-minutes: 60
     steps:
       - uses: actions/setup-go@v3


### PR DESCRIPTION
Signed-off-by: Vishwas Siravara <siravara@amazon.com>

Issue #, if available:
[53](https://github.com/runfinch/finch/issues/53)

*Description of changes:*
Change to amd64 build to run on 10.15 macos to support finch on macos 10.15

*Testing done:*
N/A , can be tested on `main` branch since workflow is triggered by `workflow_dispatch` trigger. 

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.