### PR TITLE
ci: Add signoff to sync submodule workflow

### DIFF
--- a/.github/workflows/submodulesync.yaml
+++ b/.github/workflows/submodulesync.yaml
@@ -18,4 +18,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: bump submodules
-          title: '[Automated] Bump submodules'
+          signoff: true
+          title: 'build(deps): Bump submodules'


### PR DESCRIPTION
Signed-off-by: Vishwas Siravara <siravara@amazon.com>

Issue #, if available:
N/A
*Description of changes:*
Commit by `submodulesync.yaml` workflow are not signed which leads to CI failing. [error](https://github.com/runfinch/finch-core/pull/14/checks?check_run_id=9806064207)

*Testing done:*
N/A, can only be run on the main branch. 

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.