### PR TITLE
fix: Change checksum format to support macos 10.15 build

### DIFF
--- a/hashes/socket_vmnet-1.0.0-alpha.tar.gz.sha512
+++ b/hashes/socket_vmnet-1.0.0-alpha.tar.gz.sha512
@@ -1,2 +1,2 @@
 # https://deps.runfinch.com/socket_vmnet-1.0.0-alpha.tar.gz
-SHA512 (socket_vmnet-1.0.0-alpha.tar.gz) = 4dd2b400580e010f2d7bd177b87e7e12d1914da3ea618b76709c763729de6eb07cc6a09c5e196de9b8fd254ffa683938734e10254cecd6431943b6a5b46864e3
+4dd2b400580e010f2d7bd177b87e7e12d1914da3ea618b76709c763729de6eb07cc6a09c5e196de9b8fd254ffa683938734e10254cecd6431943b6a5b46864e3 *socket_vmnet-1.0.0-alpha.tar.gz


### PR DESCRIPTION
Signed-off-by: Vishwas Siravara <siravara@amazon.com>

Issue #, if available:

*Description of changes:*
checksum check fails on macos 10.15 because of unsupported checksum format since macos 10.15 uses an older version of `shasum`. [error log](https://github.com/runfinch/finch/actions/runs/3587857287/jobs/6038648735)

*Testing done:*
Yes.

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.