### PR TITLE
ci: Change trigger to schedule and sync lima with release tags

### DIFF
--- a/.github/workflows/submodulesync.yaml
+++ b/.github/workflows/submodulesync.yaml
@@ -1,7 +1,9 @@
 name: Sync Submodules
 
 on:
-  workflow_dispatch:
+  schedule:
+    - cron: '0 9 * * 1'
+
 jobs:
   update:
     runs-on: ubuntu-latest
@@ -12,7 +14,12 @@ jobs:
           submodules: recursive
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Update sub modules
-        run: git submodule update --remote
+        run: |
+          git submodule update --remote
+          TAG=`cd src/lima && git describe --tags $(git rev-list --tags --max-count=1)`
+          echo "Pulling changes from release: $TAG"
+          cd src/lima && git checkout $TAG
+
       - name: Create PR
         uses: peter-evans/create-pull-request@v4
         with:


### PR DESCRIPTION
Issue #, if available:
N/A
*Description of changes:*
1. Change trigger to cron expression for building deep dependencies. The build will run every Monday at 9am UTC. 
2. Sync lima dependency from latest release tag rather than `main` branch. 
*Testing done:*


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.