### PR TITLE
fix: Add command to fetch remote tags

### DIFF
--- a/.github/workflows/submodulesync.yaml
+++ b/.github/workflows/submodulesync.yaml
@@ -16,6 +16,7 @@ jobs:
       - name: Update sub modules
         run: |
           git submodule update --remote
+          cd src/lima && git fetch --tags
           TAG=`cd src/lima && git describe --tags $(git rev-list --tags --max-count=1)`
           echo "Pulling changes from release: $TAG"
           cd src/lima && git checkout $TAG


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Fix to fetch remote tags for sub modules in order to checkout latest tag. 

*Testing done:*
Yes. 

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.