### PR TITLE
ci: Add workflow to upload release artifacts to s3 on new release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,6 +10,7 @@ jobs:
       - uses: google-github-actions/release-please-action@v3
         with:
           release-type: go
+          token: ${{ FINCH_BOT_TOKEN }}
           package-name: finch
           # Before we are at v1.0.0
           bump-minor-pre-major: true

--- a/.github/workflows/upload-release-s3.yaml
+++ b/.github/workflows/upload-release-s3.yaml
@@ -1,0 +1,37 @@
+# Trigger the workflow on creating a new release/tag
+
+name: Publish release to s3
+
+# Controls when the workflow will run
+on:
+  create:
+    tags:
+      - '*'
+permissions:
+  # This is required for configure-aws-credentials to request an OIDC JWT ID token to access AWS resources later on.
+  # More info: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
+  id-token: write
+  contents: read    # This is required for actions/checkout
+
+jobs:
+  upload-please:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download last release
+        uses: robinraju/release-downloader@v1.7
+        with:
+          repository: "runfinch/finch-core"
+          latest: true
+          tarBall: true
+          zipBall: true
+
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.ROLE }}
+          role-session-name: upload release
+          aws-region: ${{ secrets.REGION }}
+
+      - name: Upload release artifacts to s3
+        run: |
+          aws s3 cp . s3://${{ secrets.ARTIFACT_BUCKET_NAME }} --recursive --exclude "*" --include "finch-core*"


### PR DESCRIPTION
Signed-off-by: Vishwas Siravara <siravara@amazon.com>

Issue #, if available:

*Description of changes:*
Workflow to upload core release to s3. 

*Testing done:*
On a private repo with `robinraju/release-downloader@v1.7` action. 

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.