### PR TITLE
ci: Remove install-deps dependency in download-sources target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ install-deps: lima
 	sha512sum src/lima/lima-and-qemu.macos-${LIMA_ARCH}.${BUILD_TS}.tar.gz | cut -d " " -f 1  > src/lima/lima-and-qemu.macos-${LIMA_ARCH}.${BUILD_TS}.tar.gz.sha512sum
 
 .PHONY: download-sources
-download-sources: install-deps
+download-sources:
 	./bin/download-sources.pl
 	mv ./downloads/dependency-sources.tar.gz ./downloads/dependency-sources-${LIMA_ARCH}.${BUILD_TS}.tar.gz
 


### PR DESCRIPTION
Signed-off-by: Vishwas Siravara <siravara@amazon.com>

Issue #, if available:

*Description of changes:*
Remove unnecessary dependency in `Makefile` for `download-sources` target. 

*Testing done:*
Yes

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.