### PR TITLE
ci: Revert back to GITHUB_TOKEN for release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,7 +10,6 @@ jobs:
       - uses: google-github-actions/release-please-action@v3
         with:
           release-type: go
-          token: ${{ secrets.FINCH_BOT_TOKEN }}
           package-name: finch
           # Before we are at v1.0.0
           bump-minor-pre-major: true

--- a/.github/workflows/upload-release-s3.yaml
+++ b/.github/workflows/upload-release-s3.yaml
@@ -4,9 +4,8 @@ name: Publish release to s3
 
 # Controls when the workflow will run
 on:
-  create:
-    tags:
-      - '*'
+  workflow_dispatch:
+
 permissions:
   # This is required for configure-aws-credentials to request an OIDC JWT ID token to access AWS resources later on.
   # More info: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Change token to `GITHUB_TOKEN` since `FINCH_BOT_TOKEN` is read-only and cannot create releases. Change trigger of https://github.com/vsiravar/finch-core-public/blob/5300cecc342c5335ea501b56655c67f6b7295bd5/.github/workflows/upload-release-s3.yaml#L7 since resources created by `release-please` cannot trigger github actions as described [here](https://github.com/google-github-actions/release-please-action#github-credentials).  

*Testing done:*
Yes. 

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.