### PR TITLE
fix: properly set socket_vmnet version

### DIFF
--- a/hashes/socket_vmnet-1.0.0-alpha.tar.gz.sha512
+++ b/hashes/socket_vmnet-1.0.0-alpha.tar.gz.sha512
@@ -1,2 +1,0 @@
-# https://deps.runfinch.com/socket_vmnet-1.0.0-alpha.tar.gz
-4dd2b400580e010f2d7bd177b87e7e12d1914da3ea618b76709c763729de6eb07cc6a09c5e196de9b8fd254ffa683938734e10254cecd6431943b6a5b46864e3 *socket_vmnet-1.0.0-alpha.tar.gz


### PR DESCRIPTION
Signed-off-by: Justin Alvarez <alvajus@amazon.com>

Issue #, if available: https://github.com/runfinch/finch/issues/21

*Description of changes:*
Updates the socket_vmnet target to use the submodule which fixes the version issue.

*Testing done:*
- Tested locally with latest finch main commit:
```shell
$ make lima-socket-vmnet
$ ./_output/dependencies/lima-socket_vmnet/opt/finch/bin/socket_vmnet --version
> v1.1.0-4-g910aaef
```

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.