### PR TITLE
ci: Add schedule for dependency build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,11 @@
 name: Build
 
+# Runs every Tuesday at 9 am UTC
 on:
+  schedule:
+    - cron: '0 9 * * 2'
   workflow_dispatch:
+
 env:
   GO111MODULE: on
 


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
In addition to workflow_dispatch, schedule building dependencies of finch every Tuesday at 9 UTC. 

*Testing done:*


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.