### PR TITLE
ci: Add workflow_dispatch trigger for off cycle release

### DIFF
--- a/.github/workflows/submodulesync.yaml
+++ b/.github/workflows/submodulesync.yaml
@@ -3,6 +3,7 @@ name: Sync Submodules
 on:
   schedule:
     - cron: '0 9 * * 1'
+  workflow_dispatch:
 
 jobs:
   update:


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Add `workflow_dispatch` trigger for off cycle submodule updates. 

*Testing done:*

Yes. Link: https://github.com/vsiravar/finch-core-public/actions/runs/4319003051

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.