### PR TITLE
ci: vsiravar/fix dependency build job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -141,7 +141,7 @@ jobs:
       - name: Download MacOS dependencies' sources
         uses: actions/download-artifact@v3
         with:
-          name: DependenciesSourceCode.zip
+          name: DependenciesSourceCode.tar.gz
           path: build
 
       - name: "Upload to S3"

--- a/.github/workflows/submodulesync.yaml
+++ b/.github/workflows/submodulesync.yaml
@@ -3,6 +3,7 @@ name: Sync Submodules
 on:
   schedule:
     - cron: '0 9 * * 1'
+  workflow_dispatch:
 
 jobs:
   update:


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Fix typo which leads to https://github.com/runfinch/finch-core/actions/runs/4352384603/jobs/7620373594 exception while downloading dependency source code for uploading to s3 bucket. 

*Testing done:*


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.