### PR TITLE
ci: Fix typo in dependency build job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -141,7 +141,7 @@ jobs:
       - name: Download MacOS dependencies' sources
         uses: actions/download-artifact@v3
         with:
-          name: DependenciesSourceCode.zip
+          name: DependenciesSourceCode.tar.gz
           path: build
 
       - name: "Upload to S3"


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Fix typo which causes https://github.com/runfinch/finch-core/actions/runs/4352384603/jobs/7620373594 exception. 

*Testing done:*


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.