### PR TITLE
ci: Add e2e tests for merge validations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,55 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'src/**'
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'contrib/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [[self-hosted, macos, amd64, 11.7], [self-hosted, macos, amd64, 12.6], [self-hosted, macos, arm64, 11.7], [self-hosted, macos, arm64, 12.6]]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          submodules: true
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: e2e/go.mod
+          cache: true
+      - name: Clean up previous files
+        run: |
+          sudo rm -rf ~/.lima
+          sudo rm -rf ./_output
+          if pgrep '^qemu-system'; then
+            sudo pkill '^qemu-system'
+          fi
+          if pgrep '^socket_vmnet'; then
+            sudo pkill '^socket_vmnet'
+          fi
+      - name: Build project
+        run: |
+          export PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH"
+          which libtool
+          # Install socket_vmnet to `_output/bin` which is used in $PATH
+          SOCKET_VMNET_TEMP_PREFIX=$(pwd)/_output/ make lima-socket-vmnet
+          make install.lima-dependencies 
+      - run: make test-e2e

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -1,0 +1,42 @@
+name: Update dependencies
+on:
+  schedule:
+    - cron: '0 11 * * 2'
+  workflow_dispatch:
+
+permissions:
+  # This is required for configure-aws-credentials to request an OIDC JWT ID token to access AWS resources later on.
+  # More info: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-deps:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.ROLE }}
+          role-session-name: dependency-upload-session
+          aws-region: ${{ secrets.REGION }}
+
+      # This step fetches the latest set of released dependencies from s3 and updates the Makefile to use the same.
+      - name: update dependencies url
+        run: |
+          ./bin/update-deps.sh -d ${{ secrets.DEPENDENCY_BUCKET_NAME }}
+
+      - name: create PR
+        uses: peter-evans/create-pull-request@v4
+        with:
+          # A Personal Access Token instead of the default `GITHUB_TOKEN` is required
+          # to trigger the checks (e.g., e2e tests) on the created pull request.
+          # More info: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs
+          # TODO: Use FINCH_BOT_TOKEN instead of GITHUB_TOKEN.
+          token: ${{ secrets.GITHUB_TOKEN }}
+          signoff: true
+          title: 'build(deps): Bump finch dependencies'

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ OUTDIR ?= $(CURDIR)/_output
 HASH_DIR ?= $(CURDIR)/hashes
 DOWNLOAD_DIR := $(CURDIR)/downloads
 OS_DOWNLOAD_DIR := $(DOWNLOAD_DIR)/os
+LIMA_DOWNLOAD_DIR := $(DOWNLOAD_DIR)/dependencies
 DEPENDENCIES_DOWNLOAD_DIR :=  $(DOWNLOAD_DIR)/dependencies
 SOCKET_VMNET_TEMP_PREFIX ?= $(OUTDIR)/dependencies/lima-socket_vmnet/opt/finch
 UNAME := $(shell uname -m)
@@ -59,15 +60,17 @@ download.os: $(OS_DOWNLOAD_DIR)/$(FINCH_OS_BASENAME)
 .PHONY: download
 download: download.os
 
+$(LIMA_DOWNLOAD_DIR)/$(LIMA_DEPENDENCY_FILE_NAME):
+	mkdir -p $(DEPENDENCIES_DOWNLOAD_DIR)
+	curl -L --fail $(LIMA_URL) > "$(DEPENDENCIES_DOWNLOAD_DIR)/$(LIMA_DEPENDENCY_FILE_NAME)"
+	mkdir -p ${OUTDIR}
+	tar -xvzf ${DEPENDENCIES_DOWNLOAD_DIR}/${LIMA_DEPENDENCY_FILE_NAME} -C ${OUTDIR}
+
 .PHONY: download.lima-dependencies
-download.lima-dependencies:
-	mkdir -p ${DEPENDENCIES_DOWNLOAD_DIR}
-	curl -L --fail $(LIMA_URL) > "$(DEPENDENCIES_DOWNLOAD_DIR)/${LIMA_DEPENDENCY_FILE_NAME}"
+download.lima-dependencies: $(LIMA_DOWNLOAD_DIR)/$(LIMA_DEPENDENCY_FILE_NAME)
 
 .PHONE: install.lima-dependencies
 install.lima-dependencies: download.lima-dependencies
-	mkdir -p ${OUTDIR}
-	tar -xvzf ${DEPENDENCIES_DOWNLOAD_DIR}/${LIMA_DEPENDENCY_FILE_NAME} -C ${OUTDIR}
 
 .PHONY: lima-template
 lima-template: download

--- a/bin/update-deps.sh
+++ b/bin/update-deps.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+DEPENDENCY_CLOUDFRONT_URL="https://deps.runfinch.com/"
+AARCH64_FILENAME_PATTERN="aarch64/lima-and-qemu.macos-aarch64.[0-9].*\.gz$"
+AMD64_FILENAME_PATTERN="x86-64/lima-and-qemu.macos-x86_64.[0-9].*\.gz$"
+AARCH64="aarch64"
+X86_64="x86-64"
+
+set -x
+
+while getopts d: flag
+do
+        case "${flag}" in
+            d) dependency_bucket=${OPTARG};;
+         esac
+done
+[[ -z "$dependency_bucket" ]] && { echo "Error: Dependency bucket not set"; exit 1; }
+
+
+aarch64Deps=$(aws s3 ls s3://${dependency_bucket}/${AARCH64}/ --recursive | grep "$AARCH64_FILENAME_PATTERN" | sort | tail -n 1 | awk '{print $4}')
+
+[[ -z "$aarch64Deps" ]] && { echo "Error: aarch64 dependency not found"; exit 1; }
+
+
+amd64Deps=$(aws s3 ls s3://${dependency_bucket}/${X86_64}/ --recursive | grep "$AMD64_FILENAME_PATTERN" | sort | tail -n 1 | awk '{print $4}')
+
+[[ -z "$amd64Deps" ]] && { echo "Error: x86_64 dependency not found"; exit 1; }
+
+sed -E  -i.bak  's|^([[:blank:]]*LIMA_URL[[:blank:]]*\?=[[:blank:]]*'${DEPENDENCY_CLOUDFRONT_URL}')('${AARCH64_FILENAME_PATTERN}')|\1'$aarch64Deps'|' Makefile
+sed -E  -i.bak  's|^([[:blank:]]*LIMA_URL[[:blank:]]*\?=[[:blank:]]*'${DEPENDENCY_CLOUDFRONT_URL}')('${AMD64_FILENAME_PATTERN}')|\1'$amd64Deps'|'  Makefile

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -10,27 +10,97 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"github.com/runfinch/common-tests/command"
 	"github.com/runfinch/common-tests/option"
 	"github.com/runfinch/common-tests/tests"
 )
 
 func TestE2e(t *testing.T) {
-	description := "Finch Core e2e Tests"
+	description := "Finch Core E2E Tests"
 
+	limaRelativePath := "./../_output/bin/"
+	limaAbsPath, err := filepath.Abs(limaRelativePath)
+	if err != nil {
+		t.Fatalf("Error getting absolute path: %v", err)
+	}
+	// Add custom qemu to path
+	currentPath := os.Getenv("PATH")
+
+	// Put ./../_output/bin first on path to override other installations of lima and qemu
+	newPath := limaAbsPath + string(os.PathListSeparator) + currentPath
+	err = os.Setenv("PATH", newPath)
+
+	if err != nil {
+		t.Fatalf("Error setting PATH: %v", err)
+	}
 	wd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("failed to get the current working directory: %v", err)
 	}
-	limactl := filepath.Join(wd, "../_output/lima/bin/limactl")
+	subject := "limactl"
+	vmConfigFile := filepath.Join(wd, "./fedora.yaml")
+	vmName := "fedora"
+	o, err := option.New([]string{subject})
 
-	o, err := option.New([]string{limactl, "shell", "fedora", "nerdctl"})
+	ginkgo.SynchronizedBeforeSuite(func() []byte {
+		command.New(o, "start", vmConfigFile).WithTimeoutInSeconds(600).Run()
+		return nil
+	}, func(bytes []byte) {})
+
+	ginkgo.SynchronizedAfterSuite(func() {
+		command.New(o, "stop", vmName).WithTimeoutInSeconds(90).Run()
+		command.New(o, "remove", vmName).WithTimeoutInSeconds(60).Run()
+	}, func() {})
+
+	opt, err := option.New([]string{subject, "shell", "fedora", "sudo", "-E", "nerdctl"})
 	if err != nil {
 		t.Fatalf("failed to initialize a testing option: %v", err)
 	}
 
 	ginkgo.Describe(description, func() {
 		// TODO: add more e2e tests and make them work.
-		tests.Pull(o)
+		tests.Save(opt)
+		tests.Load(opt)
+		tests.Pull(opt)
+		tests.Rm(opt)
+		tests.Rmi(opt)
+		tests.Start(opt)
+		tests.Stop(opt)
+		tests.Cp(opt)
+		tests.Tag(opt)
+		tests.Build(opt)
+		tests.Push(opt)
+		tests.Images(opt)
+		tests.ComposeBuild(opt)
+		tests.ComposeDown(opt)
+		tests.ComposeKill(opt)
+		tests.ComposePs(opt)
+		tests.ComposePull(opt)
+		tests.ComposeLogs(opt)
+		tests.Create(opt)
+		tests.Port(opt)
+		tests.Kill(opt)
+		tests.Stats(opt)
+		tests.BuilderPrune(opt)
+		tests.Exec(opt)
+		tests.Logs(opt)
+		tests.Login(opt)
+		tests.Logout(opt)
+		tests.VolumeCreate(opt)
+		tests.VolumeInspect(opt)
+		tests.VolumeLs(opt)
+		tests.VolumeRm(opt)
+		tests.VolumePrune(opt)
+		tests.ImageHistory(opt)
+		tests.ImageInspect(opt)
+		tests.ImagePrune(opt)
+		tests.Info(opt)
+		tests.Events(opt)
+		tests.Inspect(opt)
+		tests.NetworkCreate(opt)
+		tests.NetworkInspect(opt)
+		tests.NetworkLs(opt)
+		tests.NetworkRm(opt)
 	})
 
 	gomega.RegisterFailHandler(ginkgo.Fail)

--- a/e2e/fedora.yaml
+++ b/e2e/fedora.yaml
@@ -1,0 +1,191 @@
+# ===================================================================== #
+# BASIC CONFIGURATION
+# ===================================================================== #
+
+# Default values in this YAML file are specified by `null` instead of Lima's "builtin default" values,
+# so they can be overridden by the $LIMA_HOME/_config/default.yaml mechanism documented at the end of this file.
+
+# Arch: "default", "x86_64", "aarch64".
+# 🟢 Builtin default: "default" (corresponds to the host architecture)
+arch: null
+
+# OpenStack-compatible disk image.
+# 🟢 Builtin default: null (must be specified)
+# 🔵 This file: Ubuntu 22.04 Jammy Jellyfish images
+images:
+  - location: "https://deps.runfinch.com/Fedora-Cloud-Base-37-1.7.x86_64-20230329185717.qcow2"
+    arch: "x86_64"
+    digest: "sha256:df67925e051ace602f58b1e01ed65156c975b985be1c0b24dd62f63d28d076d4"
+  - location: "https://deps.runfinch.com/Fedora-Cloud-Base-37-1.7.aarch64-20230330181518.qcow2"
+    arch: "aarch64"
+    digest: "sha256:0951ee1a69817e2ef472163af752bf4efb25486659308d22d9e72ca9b45a097f"
+
+# CPUs: if you see performance issues, try limiting cpus to 1.
+# 🟢 Builtin default: 4
+cpus: null
+
+# Memory size
+# 🟢 Builtin default: "4GiB"
+memory: "4GiB"
+
+# Disk size
+# 🟢 Builtin default: "100GiB"
+disk: null
+
+# Expose host directories to the guest, the mount point might be accessible from all UIDs in the guest
+# 🟢 Builtin default: null (Mount nothing)
+# 🔵 This file: Mount the home as read-only, /tmp/lima as writable
+mounts:
+  - location: "~"
+    # Configure the mountPoint inside the guest.
+    # 🟢 Builtin default: value of location
+    mountPoint: null
+    # CAUTION: `writable` SHOULD be false for the home directory.
+    # Setting `writable` to true is safe for finch use case.
+    # Reference: https://github.com/lima-vm/lima/discussions/550
+    writable: true
+    sshfs:
+      # Enabling the SSHFS cache will increase performance of the mounted filesystem, at
+      # the cost of potentially not reflecting changes made on the host in a timely manner.
+      # Warning: It looks like PHP filesystem access does not work correctly when
+      # the cache is disabled.
+      # 🟢 Builtin default: true
+      cache: null
+      # SSHFS has an optional flag called 'follow_symlinks'. This allows mounts
+      # to be properly resolved in the guest os and allow for access to the
+      # contents of the symlink. As a result, symlinked files & folders on the Host
+      # system will look and feel like regular files directories in the Guest OS.
+      # 🟢 Builtin default: false
+      followSymlinks: null
+      # SFTP driver, "builtin" or "openssh-sftp-server". "openssh-sftp-server" is recommended.
+      # 🟢 Builtin default: "openssh-sftp-server" if OpenSSH SFTP Server binary is found, otherwise "builtin"
+      sftpDriver: null
+    9p:
+      # Supported security models are "passthrough", "mapped-xattr", "mapped-file" and "none".
+      # 🟢 Builtin default: "mapped-xattr"
+      securityModel: null
+      # Select 9P protocol version. Valid options are: "9p2000" (legacy), "9p2000.u", "9p2000.L".
+      # 🟢 Builtin default: "9p2000.L"
+      protocolVersion: null
+      # The number of bytes to use for 9p packet payload, where 4KiB is the absolute minimum.
+      # 🟢 Builtin default: "128KiB"
+      msize: null
+      # Specifies a caching policy. Valid options are: "none", "loose", "fscache" and "mmap".
+      # Try choosing "mmap" or "none" if you see a stability issue with the default "fscache".
+      # See https://www.kernel.org/doc/Documentation/filesystems/9p.txt
+      # 🟢 Builtin default: "fscache" for non-writable mounts, "mmap" for writable mounts
+      cache: null
+  - location: "/tmp/lima"
+    # 🟢 Builtin default: false
+    # 🔵 This file: true (only for "/tmp/lima")
+    writable: true
+
+# Mount type for above mounts, such as "reverse-sshfs" (from sshocker) or "9p" (EXPERIMENTAL, from QEMU’s virtio-9p-pci, aka virtfs)
+# 🟢 Builtin default: "reverse-sshfs"
+mountType: reverse-sshfs
+
+ssh:
+  # A localhost port of the host. Forwarded to port 22 of the guest.
+  # 🟢 Builtin default: 0 (automatically assigned to a free port)
+  # NOTE: when the instance name is "default", the builtin default value is set to
+  # 60022 for backward compatibility.
+  localPort: 0
+  # Load ~/.ssh/*.pub in addition to $LIMA_HOME/_config/user.pub .
+  # This option is useful when you want to use other SSH-based
+  # applications such as rsync with the Lima instance.
+  # If you have an insecure key under ~/.ssh, do not use this option.
+  # 🟢 Builtin default: true
+  loadDotSSHPubKeys: false
+  # Forward ssh agent into the instance.
+  # 🟢 Builtin default: false
+  forwardAgent: null
+  # Forward X11 into the instance
+  # 🟢 Builtin default: false
+  forwardX11: null
+  # Trust forwarded X11 clients
+  # 🟢 Builtin default: false
+  forwardX11Trusted: null
+
+# ===================================================================== #
+# ADVANCED CONFIGURATION
+# ===================================================================== #
+
+containerd:
+  # Enable system-wide (aka rootful)  containerd and its dependencies (BuildKit, Stargz Snapshotter)
+  # 🟢 Builtin default: false
+  system: true
+  # Enable user-scoped (aka rootless) containerd and its dependencies
+  # 🟢 Builtin default: true
+  user: false
+#  # Override containerd archive
+#  # 🟢 Builtin default: hard-coded URL with hard-coded digest (see the output of `limactl info | jq .defaultTemplate.containerd.archives`)
+#  archives:
+#  - location: "~/Downloads/nerdctl-full-X.Y.Z-linux-amd64.tar.gz"
+#    arch: "x86_64"
+#    digest: "sha256:..."
+
+# Provisioning scripts need to be idempotent because they might be called
+# multiple times, e.g. when the host VM is being restarted.
+# 🟢 Builtin default: null
+provision:
+  # Install packages needed for QEMU user-mode emulation
+  - mode: system
+    script: |
+      #!/bin/bash
+      dnf install -y --setopt=install_weak_deps=False qemu-user-static-aarch64 qemu-user-static-arm qemu-user-static-x86
+  - mode: boot
+    script: |
+      systemctl stop NetworkManager-wait-online.service
+      systemctl reset-failed NetworkManager-wait-online.service
+      systemctl mask NetworkManager-wait-online.service
+  # # `user` is executed without the root privilege
+  - mode: user
+    script: |
+      #!/bin/bash
+      
+      # Enable SSHing into the VM as root (e.g., in `nerdctlConfigApplier.Apply`).
+      sudo cp ~/.ssh/authorized_keys /root/.ssh/
+      sudo chown $USER /mnt/lima-finch    
+      sudo systemctl restart containerd.service  
+
+# Probe scripts to check readiness.
+# 🟢 Builtin default: null
+# probes:
+# # Only `readiness` probes are supported right now.
+# - mode: readiness
+#   description: vim to be installed
+#   script: |
+#      #!/bin/bash
+#      set -eux -o pipefail
+#      if ! timeout 30s bash -c "until command -v vim; do sleep 3; done"; then
+#        echo >&2 "vim is not installed yet"
+#        exit 1
+#      fi
+#   hint: |
+#     vim was not installed in the guest. Make sure the package system is working correctly.
+#     Also see "/var/log/cloud-init-output.log" in the guest.
+
+# ===================================================================== #
+# FURTHER ADVANCED CONFIGURATION
+# ===================================================================== #
+
+# Specify desired QEMU CPU type for each arch.
+# You can see what options are available for host emulation with: `qemu-system-$(arch) -cpu help`.
+# Setting of instructions is supported like this: "qemu64,+ssse3".
+cpuType:
+  # 🟢 Builtin default: "cortex-a72" (or "host" when running on aarch64 host)
+  aarch64: null
+  # 🟢 Builtin default: "qemu64" (or "host" when running on x86_64 host)
+  x86_64: null
+
+firmware:
+  # Use legacy BIOS instead of UEFI. Ignored for aarch64.
+  # 🟢 Builtin default: false
+  legacyBIOS: null
+
+video:
+  # QEMU display, e.g., "none", "cocoa", "sdl", "gtk".
+  # As of QEMU v6.2, enabling this is known to have negative impact
+  # on performance on macOS hosts: https://gitlab.com/qemu-project/qemu/-/issues/334
+  # 🟢 Builtin default: "none"
+  display: null

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,6 +1,6 @@
 module finch-core
 
-go 1.18
+go 1.20
 
 require (
 	github.com/onsi/ginkgo/v2 v2.9.2


### PR DESCRIPTION
Issue #, if available:
### Why the change?
* Missing CI in finch-core. In the current state of finch-core, we don't have a way to ensure whether [dependencies built  and packaged by finch-core](https://github.com/runfinch/finch-core/blob/main/.github/workflows/release.yaml) work correctly, i.e they don't have any missing dependencies and the packaged set of dependencies can be used by `lima` based  systems such as finch. 
* We can also catch regressions in `limactl` and `nerdctl` before it is introduced to finch as the test will run against the `--subject=limactl nerdctl`. 
### Description of changes:*
* Add e2e tests and workflow for merge validations. CI will run when a PR is opened against `main` branch. Tests can also be triggered by `workflow_dispatch`.  
* Workflow to update references to dependency package periodically in the Makefile and create a PR against main branch to keep it up to date. Workflow can optionally be triggered manually by `workflow_dispatch` for off-cycle release. 

*Testing done:*
E2E test: https://github.com/vsiravar/finch-core-public/actions/runs/4571222330/jobs/8069314687 for results. 
Test for updating dependency: https://github.com/runfinch/finch-core/actions/runs/4759573969/jobs/8458989468

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.