### PR TITLE
ci: Disable auto build until limactl ventrua dependency is managed

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,8 +2,10 @@ name: Build
 
 # Runs every Tuesday at 9 am UTC
 on:
-  schedule:
-    - cron: '0 9 * * 2'
+
+# TODO: Enable auto build when we have a solution in place for managing limactl ventura dependency.
+#  schedule:
+#    - cron: '0 9 * * 2'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Disable auto builds until `limactl` dependency for macOS Ventura is managed in this repo. 

*Testing done:*
Yes. 

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.