### PR TITLE
build: checks whether os image is already downloaded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,11 +44,13 @@ all: binaries
 .PHONY: binaries
 binaries: os lima-socket-vmnet lima-template
 
-.PHONY: download.os
-download.os:
+$(OS_DOWNLOAD_DIR)/$(FINCH_OS_BASENAME):
 	mkdir -p $(OS_DOWNLOAD_DIR)
 	curl -L --fail $(FINCH_OS_IMAGE_URL) > "$(OS_DOWNLOAD_DIR)/$(FINCH_OS_BASENAME)"
 	cd $(OS_DOWNLOAD_DIR) && shasum -a 512 --check $(HASH_DIR)/$(FINCH_OS_BASENAME).sha512 || exit 1
+
+.PHONY: download.os
+download.os: $(OS_DOWNLOAD_DIR)/$(FINCH_OS_BASENAME)
 
 .PHONY: download
 download: download.os


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*

Small quality-of-life improvement that checks whether the OS image has already been downloaded before trying to download again.

Before this change, my `finch` builds were taking in the range of 30 seconds - 3 minutes. After this change, most builds only take around 5 seconds.

*Testing done:*

```sh
make # image not downloaded, redownloads image
make # image downloaded, does not redownload
```

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.