### PR TITLE
ci: Add logic to build and package limactl binary for virtualization framework

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -230,10 +230,14 @@ jobs:
           name: limactl.ventura.x86_64
           path: build
 
+      - name: Generate Timestamp
+        id: timestamp
+        run: echo "::set-output name=value::$(date +%s)"
+
       - name: Add Ventura builds to tarballs
         run: |
-          timestamp=$(date +%s)
-
+          timestamp=${{ steps.timestamp.outputs.value }}
+          
           mkdir -p build/lima-and-qemu.macos-aarch64/bin
           tar -xzf build/lima-and-qemu.macos-aarch64.tar.gz -C build/lima-and-qemu.macos-aarch64
           tar -xzf build/limactl.ventura.arm64.tar.gz -C build/lima-and-qemu.macos-aarch64/bin
@@ -254,6 +258,8 @@ jobs:
 
       - name: "Upload to S3"
         run: |
-          aws s3 cp ./build/ s3://${{ secrets.DEPENDENCY_BUCKET_NAME }}/aarch64/ --recursive --exclude "*" --include "lima-and-qemu.macos-aarch64*"
-          aws s3 cp ./build/ s3://${{ secrets.DEPENDENCY_BUCKET_NAME }}/x86-64/ --recursive --exclude "*" --include "lima-and-qemu.macos-x86_64*" 
+          timestamp=${{ steps.timestamp.outputs.value }}
+
+          aws s3 cp ./build/ s3://${{ secrets.DEPENDENCY_BUCKET_NAME }}/aarch64/ --recursive --exclude "*" --include "lima-and-qemu.macos-aarch64.${timestamp}.tar.gz*"
+          aws s3 cp ./build/ s3://${{ secrets.DEPENDENCY_BUCKET_NAME }}/x86-64/ --recursive --exclude "*" --include "lima-and-qemu.macos-x86_64.${timestamp}.tar.gz*" 
           aws s3 cp ./build/ s3://${{ secrets.DEPENDENCY_BUCKET_NAME }} --recursive --exclude "*"  --include "dependency-sources.tar.gz"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,9 +3,8 @@ name: Build
 # Runs every Tuesday at 9 am UTC
 on:
 
-# TODO: Enable auto build when we have a solution in place for managing limactl ventura dependency.
-#  schedule:
-#    - cron: '0 9 * * 2'
+  schedule:
+    - cron: '0 9 * * 2'
   workflow_dispatch:
 
 env:
@@ -51,7 +50,12 @@ jobs:
           unzip FileMonitor_1.3.0.zip -d /Applications
 
       - name: Make and release deps
-        run: make install-deps
+        run: |
+          (cd src/lima && git clean -f -d)
+          make -C src/lima PREFIX=/opt/homebrew all install
+          ./bin/lima-and-qemu.pl
+          mv src/lima/lima-and-qemu.tar.gz src/lima/lima-and-qemu.macos-aarch64.tar.gz
+
       - name: Upload MacOS build
         uses: actions/upload-artifact@v3
         with:
@@ -101,7 +105,12 @@ jobs:
           unzip FileMonitor_1.3.0.zip -d /Applications
 
       - name: Make and release deps
-        run: make install-deps
+        run: |
+          (cd src/lima && git clean -f -d)
+          make -C src/lima PREFIX=/usr/local all install
+          ./bin/lima-and-qemu.pl
+          mv src/lima/lima-and-qemu.tar.gz src/lima/lima-and-qemu.macos-x86_64.tar.gz
+
       - name: Upload MacOS build
         uses: actions/upload-artifact@v3
         with:
@@ -109,13 +118,81 @@ jobs:
           path: ./src/lima/lima-and-qemu.macos*
           if-no-files-found: error
 
+  macos-arm64-ventura-build:
+    runs-on:  ['self-hosted', 'macos', 'arm64', '12.6']
+    timeout-minutes: 60
+    steps:
+        - uses: actions/setup-go@v4
+          with:
+            go-version: 1.19.x
+        - uses: actions/checkout@v3
+          with:
+            fetch-depth: 1
+            submodules: recursive
+            persist-credentials: false
+
+        - name: "Switch Xcode version to enable macOS 13 SDK"
+          # Xcode 14.1 added support for macOS 13 SDK.
+          # Xcode is installed in build runners using xcodes: https://github.com/RobotsAndPencils/xcodes
+          run: |
+            sudo xcode-select --switch /Applications/Xcode-14.2.0.app/
+            xcrun --show-sdk-version
+
+        - name: Create Ventura limactl tarball
+          working-directory: src/lima
+          run: |
+            make clean && make exe codesign
+            tar cfz limactl.ventura.arm64.tar.gz -C _output/bin limactl
+
+        - name: Upload Ventura build
+          uses: actions/upload-artifact@v3
+          with:
+            name: limactl.ventura.arm64
+            path: src/lima/limactl.ventura.arm64.tar.gz
+            if-no-files-found: error
+
+  macos-x86_64-ventura-build:
+    runs-on:  ['self-hosted', 'macos', 'amd64', '12.6']
+    timeout-minutes: 60
+    steps:
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.19.x
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          submodules: recursive
+          persist-credentials: false
+
+      - name: "Switch Xcode version to enable macOS 13 SDK"
+        # Xcode 14.1 added support for macOS 13 SDK.
+        # Xcode is installed in build runners using xcodes: https://github.com/RobotsAndPencils/xcodes
+        run: |
+          sudo xcode-select --switch /Applications/Xcode-14.2.0.app/
+          xcrun --show-sdk-version
+
+      - name: Create Ventura limactl tarball
+        working-directory: src/lima
+        run: |
+          make clean && make exe codesign
+          tar cfz limactl.ventura.x86_64.tar.gz -C _output/bin limactl
+
+      - name: Upload Ventura build
+        uses: actions/upload-artifact@v3
+        with:
+          name: limactl.ventura.x86_64
+          path: src/lima/limactl.ventura.x86_64.tar.gz
+          if-no-files-found: error
 
   release:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     needs:
       - macos-x86-build
       - macos-arm64-build
+      - macos-x86_64-ventura-build
+      - macos-arm64-ventura-build
+
     steps:
       - uses: actions/checkout@v3
         with:
@@ -134,11 +211,40 @@ jobs:
         with:
           name: lima-and-qemu.macos-arm64
           path: build
+
       - name: Download MacOS x86_64 build
         uses: actions/download-artifact@v3
         with:
           name: lima-and-qemu.macos-x86
           path: build
+
+      - name: Download MacOS ARM64 Ventura build
+        uses: actions/download-artifact@v3
+        with:
+          name: limactl.ventura.arm64
+          path: build
+
+      - name: Download MacOS x86_64 Ventura build
+        uses: actions/download-artifact@v3
+        with:
+          name: limactl.ventura.x86_64
+          path: build
+
+      - name: Add Ventura builds to tarballs
+        run: |
+          timestamp=$(date +%s)
+
+          mkdir -p build/lima-and-qemu.macos-aarch64/bin
+          tar -xzf build/lima-and-qemu.macos-aarch64.tar.gz -C build/lima-and-qemu.macos-aarch64
+          tar -xzf build/limactl.ventura.arm64.tar.gz -C build/lima-and-qemu.macos-aarch64/bin
+          tar -czf build/lima-and-qemu.macos-aarch64.${timestamp}.tar.gz -C build/lima-and-qemu.macos-aarch64 .
+          sha512sum build/lima-and-qemu.macos-aarch64.${timestamp}.tar.gz | cut -d " " -f 1  > build/lima-and-qemu.macos-aarch64.${timestamp}.tar.gz.sha512sum
+
+          mkdir -p build/lima-and-qemu.macos-x86_64/bin
+          tar -xzf build/lima-and-qemu.macos-x86_64.tar.gz -C build/lima-and-qemu.macos-x86_64
+          tar -xzf build/limactl.ventura.x86_64.tar.gz -C build/lima-and-qemu.macos-x86_64/bin
+          tar -czf build/lima-and-qemu.macos-x86_64.${timestamp}.tar.gz -C build/lima-and-qemu.macos-x86_64 .
+          sha512sum build/lima-and-qemu.macos-x86_64.${timestamp}.tar.gz | cut -d " " -f 1  > build/lima-and-qemu.macos-x86_64.${timestamp}.tar.gz.sha512sum
 
       - name: Download MacOS dependencies' sources
         uses: actions/download-artifact@v3

--- a/Makefile
+++ b/Makefile
@@ -55,11 +55,6 @@ download.os: $(OS_DOWNLOAD_DIR)/$(FINCH_OS_BASENAME)
 .PHONY: download
 download: download.os
 
-.PHONY: lima
-lima:
-	(cd src/lima && git clean -f -d)
-	make -C src/lima PREFIX=$(HOMEBREW_PREFIX) all install
-
 .PHONY: lima-template
 lima-template: download
 	mkdir -p $(OUTDIR)/lima-template
@@ -76,12 +71,6 @@ lima-socket-vmnet:
 	git submodule update --init --recursive src/socket_vmnet
 	cd src/socket_vmnet && git clean -f -d
 	cd src/socket_vmnet && PREFIX=$(SOCKET_VMNET_TEMP_PREFIX) $(MAKE) install.bin
-
-.PHONY: install-deps
-install-deps: lima
-	./bin/lima-and-qemu.pl
-	mv src/lima/lima-and-qemu.tar.gz src/lima/lima-and-qemu.macos-${LIMA_ARCH}.${BUILD_TS}.tar.gz
-	sha512sum src/lima/lima-and-qemu.macos-${LIMA_ARCH}.${BUILD_TS}.tar.gz | cut -d " " -f 1  > src/lima/lima-and-qemu.macos-${LIMA_ARCH}.${BUILD_TS}.tar.gz.sha512sum
 
 .PHONY: download-sources
 download-sources:


### PR DESCRIPTION
Issue #, if available:
https://github.com/runfinch/finch-core/issues/92

*Description of changes:*
### Why the Change?
In order to support virtualization framework in finch, we need to build `limactl` binary for macOS 13. https://github.com/lima-vm/lima/blob/master/docs/vmtype.md#vz

### What's changed?
* Build limactl dependency on macOS 12.6 with XCode 14.2.0 which has [macOS 13.1 SDK](https://developer.apple.com/documentation/xcode-release-notes/xcode-14_2-release-notes). 
*Testing done:*
Yes. [Link](https://github.com/runfinch/finch-core/actions/runs/4747005052) 

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.