### PR TITLE
test RCA that pruning builds leads to CI failures

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -81,7 +81,7 @@ func TestE2e(t *testing.T) {
 		tests.Port(opt)
 		tests.Kill(opt)
 		tests.Stats(opt)
-		tests.BuilderPrune(opt)
+		// tests.BuilderPrune(opt)
 		tests.Exec(opt)
 		tests.Logs(opt)
 		tests.Login(opt)


### PR DESCRIPTION
Issue #, if available:



*Description of changes:*

On this repository and `finch` as well, we have seen issues with image content being missing when calling `finch save`. I have a writeup of this being due to an unpacked snapshot lingering even after prune of finch artifacts and build cache. I have been able to repro the issue locally and was able to fix by manually removing the lingering snapshot. For now, would like to further test this hypothesis by running CI on our runners.

*Testing done:*


- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.