### PR TITLE
feat: rootfs - build/upload action and Dockerfile

### DIFF
--- a/.github/workflows/rootfs.yaml
+++ b/.github/workflows/rootfs.yaml
@@ -1,0 +1,61 @@
+name: Build and Push Rootfs Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+     - 'Dockerfile'
+  workflow_dispatch:
+
+permissions:
+  # This is required for configure-aws-credentials to request an OIDC JWT ID token to access AWS resources later on.
+  # More info: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
+  id-token: write
+  contents: write
+
+jobs:
+  build-rootfs-image:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: ['amd64', 'arm64']
+    steps:
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: ${{ secrets.REGION }}
+          role-to-assume: ${{ secrets.ROLE }}
+          role-session-name: rootfs-ecr-image-upload-session
+      - name: checkout repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Image
+        uses: docker/build-push-action@v4
+        with:
+          platforms: linux/${{ matrix.arch }}
+          push: false  
+          load: true # load the image into Docker so we can create a container from it
+          tags: finch-rootfs-image-production:intermediate
+      - name: Tag and Push Container Image
+        run: |
+          TIMESTAMP=${{ steps.timestamp.outputs.value }}
+
+          docker tag finch-rootfs-image-production:intermediate ${{ secrets.ROOTFS_IMAGE_ECR_REPOSITORY_NAME }}:${{ matrix.arch }}-"$TIMESTAMP"
+          docker push ${{ secrets.ROOTFS_IMAGE_ECR_REPOSITORY_NAME }}:${{ matrix.arch }}-"$TIMESTAMP"
+      - name: Create, Compress, and Upload Rootfs
+        run: |
+          TIMESTAMP=${{ steps.timestamp.outputs.value }}
+
+          docker container create --platform linux/${{ matrix.arch }} --name ${{ matrix.arch }}-rootfs finch-rootfs-image-production:intermediate
+          docker container export -o finch-rootfs-production-${{ matrix.arch }}.tar ${{ matrix.arch }}-rootfs
+
+          zstd -z -18 finch-rootfs-production-${{ matrix.arch }}.tar -o finch-rootfs-production-${{ matrix.arch }}-"$TIMESTAMP".tar.zst
+
+          aws s3 cp ./finch-rootfs-production-${{ matrix.arch }}-"$TIMESTAMP".tar.zst s3://${{ secrets.DEPENDENCY_BUCKET_NAME }} 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# syntax = docker/dockerfile:1.4
+FROM public.ecr.aws/docker/library/fedora:38
+
+# install necessary cloud-server packages
+RUN dnf group install -y cloud-server-environment --exclude=plymouth* \
+    --exclude=geolite* \
+    --exclude=firewalld* \
+    --exclude=grub* \
+    --exclude=dracut* \
+    --exclude=shim-*
+
+RUN systemctl enable cloud-init cloud-init-local cloud-config cloud-final
+
+# enable systemd
+# disabled network conf in cloud config
+RUN <<EOF cat >> /etc/wsl.conf
+[boot]
+systemd=true
+EOF
+
+RUN <<EOF cat >> /etc/cloud/cloud.cfg
+network:
+      config: disabled
+EOF
+
+# cleanup
+RUN dnf clean all &&\
+    rm -f /etc/NetworkManager/system-connections/*.nmconnection && \
+    truncate -s 0 /etc/machine-id && \
+    rm -f /var/lib/systemd/random-seed


### PR DESCRIPTION
Issue #, if available:

https://github.com/runfinch/finch/issues/492

*Description of changes:*

In order to facilitate Finch on Windows, we need a root filesystem. We will use this Dockerfile as a basis for that root filesystem - using `docker export` to turn a built container into an archived rootfs. For the scope of these changes, create the Dockerfile and an action that runs on changes to the file to build and push to ECR repo.

The Dockerfile will be used to create a container such that we can export that container's fs as a tarball and compress it for use with WSL2. For now, we are including cloud-init (at least for the WSL2 rootfs) but need further investigation to determine if we can remove the package to further slim the rootfs..

In order to create the container used as an intermediate step to export
its rootfs, we need to tell buildkit to load the image into Docker. See 
This exposes a limitation of buildkit to load multiplatform images:

`buildx failed with: ERROR: docker exporter does not currently support exporting manifest lists`

thus why the action runs two build-rootfs-image jobs - one for each arch.

See https://github.com/docker/buildx/issues/59 and https://github.com/docker/roadmap/issues/371

Additionally, network performance of the arm64 build is quite slow -
downloads of packages via dnf are on the scale of kb/s (but this has not
been observed on Ubuntu or Alpine images)


*Testing done:*

Local copy in a private repo, [`act`](https://github.com/nektos/act)

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.