### PR TITLE
fix: quote recursive calls to make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ lima-template: download
 lima-socket-vmnet:
 	git submodule update --init --recursive src/socket_vmnet
 	cd src/socket_vmnet && git clean -f -d
-	cd src/socket_vmnet && PREFIX=$(SOCKET_VMNET_TEMP_PREFIX) $(MAKE) install.bin
+	cd src/socket_vmnet && PREFIX=$(SOCKET_VMNET_TEMP_PREFIX) "$(MAKE)" install.bin
 
 .PHONY: download-sources
 download-sources:


### PR DESCRIPTION

Issue #, if available:

*Description of changes:*

$(MAKE) is used for calling `make` recursively. On a Windows machine, `make` might be at some location containing a space or special character, like /c/Program Files (x86)/GnuWin32/bin/make . Wrap in quotes as "$(MAKE)" to prevent errors.



*Testing done:*

`make` on macOS and Windows.


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.