### PR TITLE
ci: use bash instead of sh

### DIFF
--- a/bin/update-deps.sh
+++ b/bin/update-deps.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 DEPENDENCY_CLOUDFRONT_URL="https://deps.runfinch.com/"
 AARCH64_FILENAME_PATTERN="aarch64/lima-and-qemu.macos-aarch64.[0-9].*\.gz$"

--- a/bin/update-rootfs.sh
+++ b/bin/update-rootfs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -euxo pipefail
 
 DEPENDENCY_CLOUDFRONT_URL="https://deps.runfinch.com/"


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*

The action "Sync Submodules and Dependencies" on finch failed with the message "set: Illegal option -o pipefail". 

https://github.com/runfinch/finch/actions/runs/5760444005/job/15616416221


*Testing done:*


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.