### PR TITLE
perf: add lima dependency pkgs to speed up VM boot

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ on:
     paths-ignore:
       - '**.md'
       - 'contrib/**'
+      - 'Dockerfile'
   workflow_dispatch:
 
 concurrency:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,15 @@ RUN dnf group install -y cloud-server-environment --exclude=plymouth* \
     --exclude=dracut* \
     --exclude=shim-*
 
+# install packages needed by Lima
+RUN dnf install -y \
+  --setopt=install_weak_deps=False \
+  qemu-user-static-aarch64 \
+  qemu-user-static-arm \
+  qemu-user-static-x86 \
+  iptables \
+  fuse-sshfs
+
 RUN systemctl enable cloud-init cloud-init-local cloud-config cloud-final
 
 # enable systemd


### PR DESCRIPTION
install packages
* qemu-user-static-aarch64
* qemu-user-static-arm
* qemu-user-static-x86
* iptables
* fuse-sshfs 

depended on by lima to decrease boot time of Finch VM on Windows

Issue #, if available:

*Description of changes:*


*Testing done:*

* EC2 Windows dev instance 
* build rootfs locally, scp up
* run Finch w/ changes in runfinch/finch#553
* basic commands tests -> `finch vm init`, `finch vm pull alpine:latest`, etc.

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.