### PR TITLE
ci: add depth for fetching all branches and history

### DIFF
--- a/.github/workflows/submodulesync.yaml
+++ b/.github/workflows/submodulesync.yaml
@@ -12,6 +12,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           submodules: recursive
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Update sub modules


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Add ` fetch-depth: 0` to fetch all history for all branches and tags inorder to checkout stable commit. 

*Testing done:*


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.