### PR TITLE
fix: track pendo324/lima windows-ssh-quoting until quoting fixed upstream

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "src/lima"]
 	path = src/lima
-	url = https://github.com/lima-vm/lima
+	url = https://github.com/pendo324/lima
+	branch = windows-ssh-quoting
 [submodule "src/socket_vmnet"]
 	path = src/socket_vmnet
 	url = https://github.com/lima-vm/socket_vmnet


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Tracks a Lima fork until the SSH quoting issue is resolved upstream.

You probably need to run `git submodule set-url src/lima https://github.com/pendo324/lima` and `git submodule update --init --recursive` to get the latest changes

*Testing done:*


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.