### PR TITLE
chore: track lima master now that quote fix is merged

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "src/lima"]
 	path = src/lima
-	url = https://github.com/pendo324/lima
-	branch = windows-ssh-quoting
+	url = https://github.com/lima-vm/lima
 [submodule "src/socket_vmnet"]
 	path = src/socket_vmnet
 	url = https://github.com/lima-vm/socket_vmnet


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Since the ssh quote fix is merged, we can track Lima's `master` branch again

*Testing done:*


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.