### PR TITLE
fix: remove old version of msys-crypto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,8 +171,6 @@ $(LIMA_OUTDIR)/bin/ssh.exe:
 
 	# Required by ssh.exe, from https://packages.msys2.org/package/libopenssl?repo=msys&variant=x86_64
 	cp $(WINGIT_TEMP_DIR)/usr/bin/msys-crypto-3.dll $(LIMA_OUTDIR)/bin/
-	# Required by ssh-keygen.exe, from https://packages.msys2.org/package/libopenssl?repo=msys&variant=x86_64
-	cp $(WINGIT_TEMP_DIR)/usr/bin/msys-crypto-1.1.dll $(LIMA_OUTDIR)/bin/
 	# Required by ssh.exe, from https://packages.msys2.org/package/zlib-devel?repo=msys&variant=x86_64
 	cp $(WINGIT_TEMP_DIR)/usr/bin/msys-z.dll $(LIMA_OUTDIR)/bin/
 	# Required by ssh.exe, from https://packages.msys2.org/package/libcrypt?repo=msys&variant=x86_64


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Remove old version of msys-crypto
  - Accidentally added because I looked at the DLLs required for an older version of `ssh-keygen.exe`, newer versions don't need this file

*Testing done:*
- Tested on my windows machine

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.