### PR TITLE
fix: use --force-local in tar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ $(LIMA_OUTDIR)/bin/ssh.exe:
 	pwsh.exe -NoLogo -NoProfile -c ./verify_hash.ps1 "$(DEPENDENCIES_DOWNLOAD_DIR)\$(WINGIT_x86_BASENAME)" $(WINGIT_x86_HASH)
 	mkdir -p $(WINGIT_TEMP_DIR)
 	# this takes a long time because of an almost 4:1 compression ratio and needing to extract many small files
-	tar -xvjf "$(DEPENDENCIES_DOWNLOAD_DIR)\$(WINGIT_x86_BASENAME)" -C $(WINGIT_TEMP_DIR)
+	tar --force-local -xvjf "$(DEPENDENCIES_DOWNLOAD_DIR)\$(WINGIT_x86_BASENAME)" -C $(WINGIT_TEMP_DIR)
 	
 	# Lima runtime dependencies
 	mkdir -p $(LIMA_OUTDIR)/bin


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*

tar option --force-local is used to instruct tar that the input is known to be a local file even if it is interpreted by tar to be a remote file; this appears to have been the case for the wingit local archive as seen in https://github.com/runfinch/finch/actions/runs/6501797014/job/17659749228

https://www.gnu.org/software/tar/manual/html_section/All-Options.html

*Testing done:*

`make` on windows instance

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.