### PR TITLE
ci: install yarn on runner  before yarn install

### DIFF
--- a/.github/workflows/cdk-e2e.yaml
+++ b/.github/workflows/cdk-e2e.yaml
@@ -41,7 +41,9 @@ jobs:
           node-version: '18'
 
       - name: Install dependencies
-        run: yarn install
+        run: |
+          npm install --global yarn
+          yarn install
 
       # Setting Node options and running lerna build
       - name: Build with lerna


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Install yarn on ec2 runners while executing cdk integration tests

*Testing done:*
Yes

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.