### PR TITLE
ci: Increase the dependency build timeout to 2 hours

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   macos-arm64-build:
     runs-on: [self-hosted, macos, arm64, 11, release]
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
         with:
@@ -77,7 +77,7 @@ jobs:
 
   macos-x86-build:
     runs-on: [self-hosted, macos, amd64, 11, release]
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
The dependency update step can exceed 1 hour, update the timeout to 2 hours
https://github.com/runfinch/finch-core/actions/runs/7098467075/job/19340092516

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.