### PR TITLE
ci: track unreleased Lima commit to fix issue with Windows lima-guestagent communication

### DIFF
--- a/.github/workflows/submodulesync.yaml
+++ b/.github/workflows/submodulesync.yaml
@@ -18,10 +18,13 @@ jobs:
       - name: Update sub modules
         run: |
           git submodule update --remote
-          (cd src/lima && git fetch --tags)
-          TAG=`cd src/lima && git describe --tags $(git rev-list --tags --max-count=1)`
-          echo "Pulling changes from release: $TAG"
-          (cd src/lima && git checkout $TAG)
+          # pin submodule to a commit, https://github.com/lima-vm/lima/commit/bd7442e34ebdccb4945828a007b5d102781bea92
+          (cd src/lima && git checkout bd7442e34ebdccb4945828a007b5d102781bea92)
+          # TODO: Track back release once lima releases version after v0.19.1
+          # (cd src/lima && git fetch --tags)
+          #  TAG=`cd src/lima && git describe --tags $(git rev-list --tags --max-count=1)`
+          # echo "Pulling changes from release: $TAG"
+          #  (cd src/lima && git checkout $TAG)
 
       - name: Create PR
         uses: peter-evans/create-pull-request@v5


### PR DESCRIPTION
Issue #, if available: e2e test failures on https://github.com/runfinch/finch/pull/649/

*Description of changes:*
- Track Lima commit that fixes underlying issue with guestagent communication, which ultimately breaks port forwarding (which is why the e2e tests are failing). See https://github.com/lima-vm/lima/pull/2118 for more details

*Testing done:*
- tested on a Windows machine by compiling Lima

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.