### PR TITLE
fix: properly checkout lima tags and pin all actions

### DIFF
--- a/.github/workflows/cdk-e2e.yaml
+++ b/.github/workflows/cdk-e2e.yaml
@@ -36,13 +36,13 @@ jobs:
           fi
 
       - name: Checkout AWS CDK main branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           repository: aws/aws-cdk
           ref: main
 
       - name: Configure Node.js version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version: "18"
 
@@ -61,7 +61,7 @@ jobs:
           NODE_OPTIONS: "--max-old-space-size=8192"
 
       - name: Checkout Finch main branch with submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           repository: runfinch/finch
           ref: main
@@ -70,7 +70,7 @@ jobs:
 
       # Setup Go using version specified in go.mod
       - name: Setup Go from Finch's go.mod
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version-file: finch-temp/go.mod
 
@@ -91,7 +91,7 @@ jobs:
           finch vm init
 
       - name: Run integration tests
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
         with:
           timeout_minutes: 180
           max_attempts: 3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,13 +34,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
           persist-credentials: false
           submodules: true
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version-file: e2e/go.mod
           cache-dependency-path: e2e/go.sum

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -13,6 +13,6 @@ jobs:
     name: conventional-commit
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@e9fabac35e210fea40ca5b14c0da95a099eff26f # v.5.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,7 +7,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: google-github-actions/release-please-action@cc61a07e2da466bebbc19b3a7dd01d6aecb20d1e # v4.0.2
         with:
           release-type: go
           package-name: finch

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,13 +21,14 @@ jobs:
     runs-on: [self-hosted, macos, arm64, 11, release]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 1
+          fetch-tags: true
           submodules: recursive
           persist-credentials: false
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: 1.20.x
 
@@ -60,7 +61,7 @@ jobs:
         shell: zsh {0}
 
       - name: Upload MacOS build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           name: lima-and-qemu.macos-arm64
           path: ./src/lima/lima-and-qemu.macos*
@@ -69,7 +70,7 @@ jobs:
       - name: Make and release source code of dependencies
         run: make download-sources
       - name: Upload MacOS build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           name: DependenciesSourceCode.tar.gz
           path: ./downloads/dependency-sources.tar.gz
@@ -79,13 +80,13 @@ jobs:
     runs-on: [self-hosted, macos, amd64, 11, release]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 1
           submodules: recursive
           persist-credentials: false
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: 1.20.x
 
@@ -118,7 +119,7 @@ jobs:
         shell: zsh {0}
 
       - name: Upload MacOS build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           name: lima-and-qemu.macos-x86
           path: ./src/lima/lima-and-qemu.macos*
@@ -128,13 +129,13 @@ jobs:
     runs-on:  [self-hosted, macos, arm64, 13, release]
     timeout-minutes: 60
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
           with:
             fetch-depth: 1
             submodules: recursive
             persist-credentials: false
 
-        - uses: actions/setup-go@v5
+        - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
           with:
             go-version: 1.20.x
 
@@ -145,7 +146,7 @@ jobs:
             tar cfz limactl.ventura.arm64.tar.gz -C _output/bin limactl
 
         - name: Upload Ventura build
-          uses: actions/upload-artifact@v3
+          uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
           with:
             name: limactl.ventura.arm64
             path: src/lima/limactl.ventura.arm64.tar.gz
@@ -155,13 +156,13 @@ jobs:
     runs-on:  [self-hosted, macos, amd64, 13, release]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 1
           submodules: recursive
           persist-credentials: false
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: 1.20.x
 
@@ -172,7 +173,7 @@ jobs:
           tar cfz limactl.ventura.x86_64.tar.gz -C _output/bin limactl
 
       - name: Upload Ventura build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           name: limactl.ventura.x86_64
           path: src/lima/limactl.ventura.x86_64.tar.gz
@@ -188,38 +189,38 @@ jobs:
       - macos-arm64-ventura-build
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 1
           persist-credentials: false
 
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
           role-to-assume: ${{ secrets.ROLE }}
           role-session-name: dependency-upload-session
           aws-region: ${{ secrets.REGION }}
 
       - name: Download MacOS ARM64 build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2v3
         with:
           name: lima-and-qemu.macos-arm64
           path: build
 
       - name: Download MacOS x86_64 build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2v3
         with:
           name: lima-and-qemu.macos-x86
           path: build
 
       - name: Download MacOS ARM64 Ventura build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2v3
         with:
           name: limactl.ventura.arm64
           path: build
 
       - name: Download MacOS x86_64 Ventura build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2v3
         with:
           name: limactl.ventura.x86_64
           path: build
@@ -245,7 +246,7 @@ jobs:
           sha512sum build/lima-and-qemu.macos-x86_64.${timestamp}.tar.gz | cut -d " " -f 1  > build/lima-and-qemu.macos-x86_64.${timestamp}.tar.gz.sha512sum
 
       - name: Download MacOS dependencies' sources
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2v3
         with:
           name: DependenciesSourceCode.tar.gz
           path: build

--- a/.github/workflows/rootfs.yaml
+++ b/.github/workflows/rootfs.yaml
@@ -27,7 +27,7 @@ jobs:
         id: timestamp
         run: echo "::set-output name=value::$(date +%s)"
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
           aws-region: ${{ secrets.REGION }}
           role-to-assume: ${{ secrets.ROLE }}
@@ -35,16 +35,16 @@ jobs:
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v2
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
       - name: Build Image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
         with:
           platforms: linux/${{ matrix.arch }}
           push: false

--- a/.github/workflows/submodulesync.yaml
+++ b/.github/workflows/submodulesync.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
           submodules: recursive
@@ -26,7 +26,7 @@ jobs:
           (cd src/lima && git checkout $TAG)
 
       - name: Create PR
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@b1ddad2c994a25fbc81a28b3ec0e368bb2021c50 # v6.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: bump submodules

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
           role-to-assume: ${{ secrets.ROLE }}
           role-session-name: dependency-upload-session
@@ -32,7 +32,7 @@ jobs:
           ./bin/update-rootfs.sh -d ${{ secrets.DEPENDENCY_BUCKET_NAME }}
 
       - name: create PR
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@b1ddad2c994a25fbc81a28b3ec0e368bb2021c50 # v6.0.0
         with:
           # A Personal Access Token instead of the default `GITHUB_TOKEN` is required
           # to trigger the checks (e.g., e2e tests) on the created pull request.

--- a/.github/workflows/upload-release-s3.yaml
+++ b/.github/workflows/upload-release-s3.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download last release
-        uses: robinraju/release-downloader@v1.9
+        uses: robinraju/release-downloader@368754b9c6f47c345fcfbf42bcb577c2f0f5f395 # v1.9
         with:
           repository: "runfinch/finch-core"
           latest: true
@@ -25,7 +25,7 @@ jobs:
           zipBall: true
 
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
           role-to-assume: ${{ secrets.ROLE }}
           role-session-name: upload release


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- actually checkout Lima version tags so that limactl --version correctly reports a tag instead of a commit hash
    - https://github.com/runfinch/finch-core/compare/main...pendo324:finch-core:fix-lima-version?expand=1#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR27
- pinned all actions to commit hashes

*Testing done:*


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.