### PR TITLE
chore: update cosign version 2.2.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,13 @@ RUN dnf install -y \
   qemu-user-static-arm \
   qemu-user-static-x86 \
   iptables \
-  fuse-sshfs
+  fuse-sshfs \
+  btrfs-progs
 
 # install cosign
-RUN curl -L -O https://github.com/sigstore/cosign/releases/download/v2.0.1/cosign-2.0.1.x86_64.rpm && \
-    sudo rpm -ivh cosign-2.0.1.x86_64.rpm && \
-    rm -rf cosign-2.0.1.x86_64.rpm
+RUN curl -L -O https://github.com/sigstore/cosign/releases/download/v2.2.3/cosign-2.2.3-1.x86_64.rpm && \
+    sudo rpm -ivh cosign-2.2.3-1.x86_64.rpm && \
+    rm -rf cosign-2.2.3-1.x86_64.rpm
 
 RUN systemctl enable cloud-init cloud-init-local cloud-config cloud-final
 


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Update's cosign version to 2.2.3
- Also adds btrfs-progs, which is needed by cloud-init, but is missing in the last OS image

*Testing done:*
- Created a local image


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.