### PR TITLE
chore: update to go 1.22

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: 1.20.x
+          go-version: 1.22.x
 
       - name: Install dependencies
         # QEMU:      required by Lima itself
@@ -92,7 +92,7 @@ jobs:
 
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: 1.20.x
+          go-version: 1.22.x
 
       - name: Install dependencies
         # QEMU:      required by Lima itself
@@ -144,7 +144,7 @@ jobs:
 
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: 1.20.x
+          go-version: 1.22.x
 
       - name: Create Ventura limactl tarball
         working-directory: src/lima
@@ -174,7 +174,7 @@ jobs:
 
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: 1.20.x
+          go-version: 1.22.x
 
       - name: Create Ventura limactl tarball
         working-directory: src/lima


### PR DESCRIPTION
Issue #, if available:
- https://github.com/runfinch/finch-core/actions/runs/8988472547/job/24689380489#step:5:29

*Description of changes:*
- Latest Lima release dropped support for golang 1.20, causing our builds to fail. This bumps the go version to 1.22.x

*Testing done:*


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.