### PR TITLE
ci: migrate release-please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,7 +7,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4.1.1
+      - uses: googleapis/release-please-action@f3969c04a4ec81d7a9aa4010d84ae6a7602f86a7 # v4.1.1
         with:
           release-type: go
           package-name: finch


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Follow [migration instructions](https://github.com/google-github-actions/release-please-action?tab=readme-ov-file#migration) from the old release-please since it is now archived. We don't really do releases for this repo, but we still have the code, so may as well migrate.

*Testing done:*


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.