### PR TITLE
fix: lima dependencies on macOS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
           which libtool
           # Install socket_vmnet to `_output/bin` which is used in $PATH
           SOCKET_VMNET_TEMP_PREFIX=$(pwd)/_output/ make lima-socket-vmnet
-          make install.lima-dependencies dependencies
+          make install.dependencies
       - name: Run e2e tests
         shell: zsh {0}
         run: make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -15,16 +15,15 @@ LIMA_DEPENDENCY_FILE_NAME ?= lima-and-qemu.tar.gz
 .DEFAULT_GOAL := all
 
 .PHONY: all
-all: dependencies
+all: install.dependencies
 
-# dependencies is a make target defined by the respective platform makefile
+# install.dependencies is a make target defined by the respective platform makefile
 # pull the required finch core dependencies for the platform.
-.PHONY: dependencies
+.PHONY: install.dependencies
 
 # Rootfs required for Windows, require full OS for Mac
 FINCH_IMAGE_LOCATION ?=
 FINCH_IMAGE_DIGEST ?=
-FEDORA_YAML ?=
 BUILD_OS ?= $(OS)
 ifeq ($(BUILD_OS), Windows_NT)
 include Makefile.windows
@@ -60,5 +59,5 @@ clean:
 	-@rm ./*.tar.gz 2>/dev/null || true
 
 .PHONY: test-e2e
-test-e2e:
+test-e2e: $(LIMA_TEMPLATE_OUTDIR)/fedora.yaml
 	cd e2e && go test -timeout 30m -v ./... -ginkgo.v

--- a/Makefile.darwin
+++ b/Makefile.darwin
@@ -19,19 +19,18 @@ endif
 
 FINCH_IMAGE_LOCATION := $(OS_OUTDIR)/$(FINCH_OS_BASENAME)
 FINCH_IMAGE_DIGEST := "sha512:$(FINCH_OS_DIGEST)"
-FEDORA_YAML := fedora.yaml
 
-dependencies: download.os install.lima-dependencies lima-socket-vmnet lima-template
+install.dependencies: install.os install.lima-dependencies install.lima-socket-vmnet
 
-.PHONY: download.os
-download.os: $(OS_OUTDIR)/$(FINCH_OS_BASENAME)
+.PHONY: install.os
+install.os: $(OS_OUTDIR)/$(FINCH_OS_BASENAME)
 
 $(OS_OUTDIR)/$(FINCH_OS_BASENAME): $(OS_OUTDIR) $(CURDIR)/deps/full-os.conf
 	bash deps/install.sh --output $@ $(CURDIR)/deps/full-os.conf
 
 .PHONY: install.lima-dependencies
-install.lima-dependencies: download.lima-dependencies $(OUTDIR)
-	tar -xvzf ${LIMA_DOWNLOAD_DIR}/${LIMA_DEPENDENCY_FILE_NAME} -C $(OUTDIR)
+install.lima-dependencies: download.lima-dependencies $(LIMA_OUTDIR)
+	tar -xvzf ${LIMA_DOWNLOAD_DIR}/${LIMA_DEPENDENCY_FILE_NAME} -C $(LIMA_OUTDIR)
 
 .PHONY: download.lima-dependencies
 download.lima-dependencies: $(LIMA_DOWNLOAD_DIR)/$(LIMA_DEPENDENCY_FILE_NAME)
@@ -39,18 +38,21 @@ download.lima-dependencies: $(LIMA_DOWNLOAD_DIR)/$(LIMA_DEPENDENCY_FILE_NAME)
 $(LIMA_DOWNLOAD_DIR)/$(LIMA_DEPENDENCY_FILE_NAME): $(LIMA_DOWNLOAD_DIR) $(CURDIR)/deps/lima-bundles.conf
 	bash deps/install.sh --output $@ $(CURDIR)/deps/lima-bundles.conf
 
-.PHONY: lima-socket-vmnet
-lima-socket-vmnet:
+.PHONY: install.lima-socket-vmnet
+install.lima-socket-vmnet:
 	git submodule update --init --recursive src/socket_vmnet
 	cd src/socket_vmnet && git clean -f -d
 	cd src/socket_vmnet && PREFIX=$(SOCKET_VMNET_TEMP_PREFIX) "$(MAKE)" install.bin
 
-.PHONY: lima-template
-lima-template: $(LIMA_TEMPLATE_OUTDIR)
-	cp lima-template/fedora.yaml $(LIMA_TEMPLATE_OUTDIR)
+$(LIMA_TEMPLATE_OUTDIR)/fedora.yaml: $(LIMA_TEMPLATE_OUTDIR)
+	cp lima-template/fedora.yaml $@.template
 	# using -i.bak is very intentional, it allows the following commands to succeed for both GNU / BSD sed
 	# this sed command uses the alternative separator of "|" because the image location uses "/"
-	sed -i.bak -e "s|<image_location>|$(FINCH_IMAGE_LOCATION)|g" $(LIMA_TEMPLATE_OUTDIR)/fedora.yaml
-	sed -i.bak -e "s/<image_arch>/$(LIMA_ARCH)/g" $(LIMA_TEMPLATE_OUTDIR)/fedora.yaml
-	sed -i.bak -e "s/<image_digest>/$(FINCH_IMAGE_DIGEST)/g" $(LIMA_TEMPLATE_OUTDIR)/fedora.yaml
-	rm $(LIMA_TEMPLATE_OUTDIR)/*.yaml.bak
+	sed -i.bak -e "s|<image_location>|$(FINCH_IMAGE_LOCATION)|g" $@.template
+	sed -i.bak -e "s/<image_arch>/$(LIMA_ARCH)/g" $@.template
+	sed -i.bak -e "s/<image_digest>/$(FINCH_IMAGE_DIGEST)/g" $@.template
+
+	# Replace was successful, so cleanup .bak files
+	rm $(LIMA_TEMPLATE_OUTDIR)/*.yaml.template.bak
+
+	mv $@.template $@

--- a/Makefile.windows
+++ b/Makefile.windows
@@ -18,7 +18,7 @@ WINGIT_x86_URL := $(or $(WINGIT_x86_URL),https://github.com/git-for-windows/git/
 WINGIT_x86_BASENAME ?= $(notdir $(WINGIT_x86_URL))
 WINGIT_x86_HASH := $(or $(WINGIT_x86_HASH),"sha256:c192e56f8ed3d364acc87ad04d1f5aa6ae03c23b32b67bf65fcc6f9b8f032e65")
 
-dependencies: install.rootfs lima
+install.dependencies: install.rootfs install.lima
 
 .PHONY: install.rootfs
 install.rootfs: $(ROOTFS_OUTPUT_DIR)/$(FINCH_ROOTFS_BASENAME)
@@ -26,14 +26,14 @@ install.rootfs: $(ROOTFS_OUTPUT_DIR)/$(FINCH_ROOTFS_BASENAME)
 $(ROOTFS_OUTPUT_DIR)/$(FINCH_ROOTFS_BASENAME): $(ROOTFS_OUTPUT_DIR) $(CURDIR)/deps/rootfs.conf
 	bash deps/install.sh --output $@ $(CURDIR)/deps/rootfs.conf
 
-lima: lima-exe install.lima-dependencies-wsl2
+.PHONY: install.lima
+install.lima: lima-exe install.lima-dependencies-wsl2
 
-.PHONY: lima lima-exe
-lima-exe:
+.PHONY: lima-exe
+lima-exe: $(LIMA_OUTDIR)
 	cd src/lima && \
 	"$(MAKE)" exe _output/share/lima/lima-guestagent.Linux-x86_64
-	mkdir -p $(OUTDIR)/lima
-	cp -r src/lima/_output/* $(OUTDIR)/lima
+	cp -r src/lima/_output/* $(LIMA_OUTDIR)
 
 .PHONY: install.lima-dependencies-wsl2
 install.lima-dependencies-wsl2: $(LIMA_OUTDIR)/bin/ssh.exe

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -18,7 +18,7 @@ import (
 func TestE2e(t *testing.T) {
 	description := "Finch Core E2E Tests"
 
-	limaRelativePath := "./../_output/bin/"
+	limaRelativePath := "./../_output/lima/bin/"
 	limaAbsPath, err := filepath.Abs(limaRelativePath)
 	if err != nil {
 		t.Fatalf("Error getting absolute path: %v", err)
@@ -41,6 +41,9 @@ func TestE2e(t *testing.T) {
 	vmConfigFile := filepath.Join(wd, "./../_output/lima-template/fedora.yaml")
 	vmName := "fedora"
 	limaOpt, err := option.New([]string{subject})
+	if err != nil {
+		t.Fatalf("failed to initialize a testing option %v", err)
+	}
 	nerdctlOpt, err := option.New([]string{subject, "shell", "fedora", "sudo", "-E", "nerdctl"})
 	if err != nil {
 		t.Fatalf("failed to initialize a testing option: %v", err)


### PR DESCRIPTION
Issue #, if available:
Found while integrating ab5fc46 into finch.

*Description of changes:*
This change updates install.lima-dependencies to unpack the lima archive into _output/lima on macOS and removes the lima template used for end-to-end testing as a macOS dependency.

*Testing done:*
`make` on finch using dirty submodule.

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.