### PR TITLE
fix: make install.dependencies on Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  install-dependencies:
+    # This is a spot check for make install.dependencies on macOS and Windows platforms.
+    # Finch-core provides the core dependencies needed to run Finch such as the base OS
+    # image, rootfs, and Lima bundle. Validate the mechanism used to install the core
+    # dependencies works on the respective platforms.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-13, windows-2022]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          submodules: true
+      - name: Setup go
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version-file: e2e/go.mod
+          cache-dependency-path: e2e/go.sum
+      - name: Install platform dependencies
+        run: make install.dependencies
+      - name: Clean up dependencies
+        run: make clean
+
   e2e-tests:
     strategy:
       fail-fast: false

--- a/Makefile.windows
+++ b/Makefile.windows
@@ -16,7 +16,7 @@ endif
 WINGIT_TEMP_DIR := $(CURDIR)/wingit-temp
 WINGIT_x86_URL := $(or $(WINGIT_x86_URL),https://github.com/git-for-windows/git/releases/download/v2.42.0.windows.2/Git-2.42.0.2-64-bit.tar.bz2)
 WINGIT_x86_BASENAME ?= $(notdir $(WINGIT_x86_URL))
-WINGIT_x86_HASH := $(or $(WINGIT_x86_HASH),"sha256:c192e56f8ed3d364acc87ad04d1f5aa6ae03c23b32b67bf65fcc6f9b8f032e65")
+WINGIT_x86_HASH := $(or $(WINGIT_x86_HASH),"sha512:795a2e7e0be5ab78f2d28d0bd971961d121b9c808a95dec795343dc5af943574dcf54f63a8580c5a5102075abdae387d7a67135c165821428afc07f11ef7543d")
 
 install.dependencies: install.rootfs install.lima
 

--- a/bin/verify_hash.ps1
+++ b/bin/verify_hash.ps1
@@ -11,7 +11,7 @@ param (
     [string]$DependencyHash = 'out.png'
 )
 
-if (!(Get-FileHash -Algorithm SHA256 "$DependencyFilePath").Hash -eq $DependencyHash) {
+if (!(Get-FileHash -Algorithm SHA512 "$DependencyFilePath").Hash -eq $DependencyHash) {
     $host.SetShouldExit(-1); exit
 } else {
     Write-Output "Verified $DependencyFilePath"


### PR DESCRIPTION
Issue #, if available:

Found during integration of 91c52d7 into finch.

```
deps/install.sh: line 75: shasum: command not found
+ grep -xq '^93ff4407f289f695424d3a4fe47158f712201d2b5ffcb0033a15d64e2082ddf8ef6e2f1612fa07ebb2bc9d57b38d0a5f3164fee1418d354847716e3594bd998d$'
+ echo 'error: shasum verification failed for dependency'
+ rm -f D:/a/finch-core/finch-core/_output/os/finch-rootfs-production-amd64-1715724303.tar.gz
error: shasum verification failed for dependency
+ exit 1
make: *** [Makefile.windows:27: D:/a/finch-core/finch-core/_output/os/finch-rootfs-production-amd64-171[57](https://github.com/austinvazquez/finch-core/actions/runs/9666641032/job/26666620967#step:4:58)24303.tar.gz] Error 1
```

*Description of changes:*
This change fixes make install.dependencies on Windows. The Windows
platform relies on sha512sum tool instead of shasum tool which is
available on macOS. This change also adds a spot check for make
install.dependencies on macOS 13 and Windows to CI.

*Testing done:*
`make install.dependencies` && `make clean` is successful on macOS 13 and Windows 2022

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.