### PR TITLE
fix: typo in install script preventing MSYS Windows

### DIFF
--- a/deps/install.sh
+++ b/deps/install.sh
@@ -76,7 +76,7 @@ os="$(uname -s)"
 case "${os}" in
   "Darwin")
     ;;
-  CYGWIN*|MINGW32*|MINGW*|MYSYS*)
+  CYGWIN*|MINGW32*|MINGW*|MSYS*)
     windows=true
     ;;
   *)


### PR DESCRIPTION
Issue #, if available:
Found while integrating fd0402 in finch

*Description of changes:*
This change fixes a typo in install.sh preventing MSYS Windows

*Testing done:*


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.