### PR TITLE
ci: remove set-output command usage

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -233,7 +233,7 @@ jobs:
 
       - name: Generate Timestamp
         id: timestamp
-        run: echo "::set-output name=value::$(date +%s)"
+        run: echo "{value}={$(date +%s)}" >> $GITHUB_OUTPUT
 
       - name: Add Ventura builds to tarballs
         run: |

--- a/.github/workflows/rootfs.yaml
+++ b/.github/workflows/rootfs.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Generate Timestamp
         id: timestamp
-        run: echo "::set-output name=value::$(date +%s)"
+        run: echo "{value}={$(date +%s)}" >> $GITHUB_OUTPUT
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:


### PR DESCRIPTION
Issue #, if available:
`set-output` command is deprecated in GitHub Actions.
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

*Description of changes:*
This change refactors generate timestamp steps in release and rootfs workflows to use the recommended method for setting outputs.

*Testing done:*

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.