### PR TITLE
fix: update Finch on Windows rootfs update workflow

### DIFF
--- a/bin/update-deps.sh
+++ b/bin/update-deps.sh
@@ -16,8 +16,8 @@ PROJECT_ROOT="$(cd -- "${CURRENT_DIR}/.." && pwd)"
 source "${PROJECT_ROOT}/bin/utility.sh"
 
 DEPENDENCY_CLOUDFRONT_URL="https://deps.runfinch.com"
-AARCH64_FILENAME_PATTERN="lima-and-qemu.macos-aarch64.[0-9].*\.gz$"
-AMD64_FILENAME_PATTERN="lima-and-qemu.macos-x86_64.[0-9].*\.gz$"
+AARCH64_FILENAME_PATTERN="lima-and-qemu.macos-aarch64\.[0-9]+\.tar\.gz$"
+AMD64_FILENAME_PATTERN="lima-and-qemu.macos-x86_64\.[0-9]+\.tar\.gz$"
 AARCH64="aarch64"
 X86_64="x86-64"
 

--- a/bin/update-rootfs.sh
+++ b/bin/update-rootfs.sh
@@ -16,7 +16,7 @@ PROJECT_ROOT="$(cd -- "${CURRENT_DIR}/.." && pwd)"
 source "${PROJECT_ROOT}/bin/utility.sh"
 
 DEPENDENCY_CLOUDFRONT_URL="https://deps.runfinch.com"
-AMD64_FILENAME_PATTERN="finch-rootfs-production-amd64-[0-9]+\.tar.gz"
+AMD64_FILENAME_PATTERN="finch-rootfs-production-amd64-[0-9]+\.tar\.gz$"
 PLATFORM="common"
 # ARM not currently supported for Finch on Windows
 # AARCH64="aarch64"

--- a/bin/utility.sh
+++ b/bin/utility.sh
@@ -14,7 +14,7 @@ find_latest_object_match_from_s3() {
     local object_pattern="$1"
     local s3_bucket="$2"
 
-    object=$(aws s3 ls "s3://${s3_bucket}" --recursive | grep "${object_pattern}" | sort | tail -n 1 | awk '{print $4}')
+    object=$(aws s3 ls "s3://${s3_bucket}" --recursive | grep -E "${object_pattern}" | sort | tail -n 1 | awk '{print $4}')
     if [[ -z "$object" ]]; then
         echo "error: no match found for pattern ${object_pattern}"
         exit 1


### PR DESCRIPTION
Issue #, if available:
In #326, it was found the update rootfs workflow was not working due to the filename pattern still searching for `.zst` archives. The pattern was updated to `.gz` to match the release archives in S3; however, the regular expression does not work with grep's basic regular expression engine.

*Description of changes:*
This change updates the find in S3 utility function to use grep's extended regular expression engine and updates the filename patterns.

*Testing done:*
Tested using local aws S3 queries:

Rootfs bundle:
```
macedonv@localhost:~$ aws s3 ls s3://***/common/x86-64 --recursive | grep -E 'finch-rootfs-production-amd64-[0-9]+\.tar\.gz$' | tail -n 1 | sort | awk '{print $4}'
common/x86-64/finch-rootfs-production-amd64-1715724303.tar.gz
macedonv@localhost:~$ 
```

Lima bundle:
```
macedonv@localhost:~$ aws s3 ls s3://***/aarch64 --recursive | grep -E 'lima-and-qemu.macos-aarch64\.[0-9]+\.tar\.gz$' | tail -n 1 | sort | awk '{print $4}'
aarch64/lima-and-qemu.macos-aarch64.1719307443.tar.gz
macedonv@localhost:~$ 
```

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.