### PR TITLE
fix: build rootfs workflow for S3 upload

### DIFF
--- a/.github/workflows/rootfs.yaml
+++ b/.github/workflows/rootfs.yaml
@@ -73,4 +73,4 @@ jobs:
           fi
 
           # Upload tarball and shasum to S3
-          aws s3 cp ./finch-rootfs-production-${{ matrix.arch }}-"$TIMESTAMP".tar.gz* s3://${{ secrets.DEPENDENCY_BUCKET_NAME }}/${{ matrix.platform }}/$ARCHPATH/
+          aws s3 cp . s3://${{ secrets.DEPENDENCY_BUCKET_NAME }}/${{ matrix.platform }}/$ARCHPATH/ --exclude "*" --include "finch-rootfs-production-${{ matrix.arch }}-"$TIMESTAMP".tar.gz*"


### PR DESCRIPTION
Issue #, if available:
Found via https://github.com/runfinch/finch-core/actions/runs/9686368317

*Description of changes:*
This change fixes the build rootfs workload to upload both the tarball and shasum to S3.

*Testing done:*


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.