### PR TITLE
fix: build rootfs workflow not uploading the artifacts to S3

### DIFF
--- a/.github/workflows/rootfs.yaml
+++ b/.github/workflows/rootfs.yaml
@@ -73,4 +73,4 @@ jobs:
           fi
 
           # Upload tarball and shasum to S3
-          aws s3 cp . s3://${{ secrets.DEPENDENCY_BUCKET_NAME }}/${{ matrix.platform }}/$ARCHPATH/ --exclude "*" --include "finch-rootfs-production-${{ matrix.arch }}-"$TIMESTAMP".tar.gz*"
+          aws s3 cp . s3://${{ secrets.DEPENDENCY_BUCKET_NAME }}/${{ matrix.platform }}/$ARCHPATH/ --recursive --exclude "*" --include "finch-rootfs-production-${{ matrix.arch }}-"$TIMESTAMP".tar.gz*"


### PR DESCRIPTION
Issue #, if available:
Found via https://github.com/runfinch/finch-core/actions/runs/9686876109

*Description of changes:*
This change adds --recursive flag to the aws s3 cp command to apply the copy to S3 bucket to all files on the local path which match the artifact pattern.

*Testing done:*
Tested aws s3 cp locally using `--recursive` flag.

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.