### PR TITLE
ci: add virtualization framework (vz) testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,7 @@ jobs:
             [self-hosted, macos, arm64, 13, test],
             [self-hosted, macos, arm64, 14, test],
           ]
+        vm_type: [ "vz", "qemu" ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
@@ -95,4 +96,4 @@ jobs:
           make install.dependencies
       - name: Run e2e tests
         shell: zsh {0}
-        run: make test-e2e
+        run: FINCH_VM_TYPE=${{ matrix.vm_type }} make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ all: install.dependencies
 # Rootfs required for Windows, require full OS for Mac
 FINCH_IMAGE_LOCATION ?=
 FINCH_IMAGE_DIGEST ?=
+FINCH_VM_TYPE ?=
 BUILD_OS ?= $(OS)
 ifeq ($(BUILD_OS), Windows_NT)
 include Makefile.windows
@@ -60,4 +61,4 @@ clean:
 
 .PHONY: test-e2e
 test-e2e: $(LIMA_TEMPLATE_OUTDIR)/fedora.yaml
-	cd e2e && go test -timeout 30m -v ./... -ginkgo.v
+	cd e2e && VM_TYPE=$(FINCH_VM_TYPE) go test -timeout 30m -v ./... -ginkgo.v

--- a/Makefile.darwin
+++ b/Makefile.darwin
@@ -20,6 +20,10 @@ endif
 FINCH_IMAGE_LOCATION := $(OS_OUTDIR)/$(FINCH_OS_BASENAME)
 FINCH_IMAGE_DIGEST := "sha512:$(FINCH_OS_DIGEST)"
 
+# Virtualization framework is the default virtual machine type on Finch on macOS
+# This is only used for testing of Finch core bundles.
+FINCH_VM_TYPE ?= vz
+
 install.dependencies: install.os install.lima-dependencies install.lima-socket-vmnet
 
 .PHONY: install.os

--- a/Makefile.windows
+++ b/Makefile.windows
@@ -13,6 +13,9 @@ else
 $(error Finch on Windows ARM not supported)
 endif
 
+# WSL2 is the only virtual machine type supported for Finch on Windows
+FINCH_VM_TYPE := wsl2
+
 WINGIT_TEMP_DIR := $(CURDIR)/wingit-temp
 WINGIT_x86_URL := $(or $(WINGIT_x86_URL),https://github.com/git-for-windows/git/releases/download/v2.42.0.windows.2/Git-2.42.0.2-64-bit.tar.bz2)
 WINGIT_x86_BASENAME ?= $(notdir $(WINGIT_x86_URL))


### PR DESCRIPTION
Issue #, if available:
Closes #351 

*Description of changes:*
This change updates the test matrix for e2e to test both Qemu and Virtualization framework (VZ) virtual machines on macOS.

*Testing done:*
CI is successful

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.