### PR TITLE
ci: drop patch from Go min version

### DIFF
--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,6 +1,6 @@
 module finch-core
 
-go 1.22.0
+go 1.22
 
 require (
 	github.com/onsi/ginkgo/v2 v2.19.0


### PR DESCRIPTION
Issue #, if available:
Go in CI is using Go 1.22.0 even though new versions are available.

*Description of changes:*
This change drops the patch version from the min version in go.mod.

*Testing done:*
CI is successful

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.