### PR TITLE
ci: fix set timestamp output

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -233,7 +233,7 @@ jobs:
 
       - name: Generate Timestamp
         id: timestamp
-        run: echo "{value}={$(date +%s)}" >> $GITHUB_OUTPUT
+        run: echo "value=$(date +%s)" >> $GITHUB_OUTPUT
 
       - name: Add Ventura builds to tarballs
         run: |

--- a/.github/workflows/rootfs.yaml
+++ b/.github/workflows/rootfs.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Generate Timestamp
         id: timestamp
-        run: echo "{value}={$(date +%s)}" >> $GITHUB_OUTPUT
+        run: echo "value=$(date +%s)" >> $GITHUB_OUTPUT
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:


### PR DESCRIPTION
Issue #, if available:
Latest rootfs build did not have timestamp set.

*Description of changes:*
This change fixes the set timestamp bug introduced with #342

*Testing done:*
Ran change in fork CI

![image](https://github.com/runfinch/finch-core/assets/55906459/d9335b47-e13f-4cb6-a345-7dcd76c2ebb2)

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.