### PR TITLE
build(fix): use arch that's passed in instead of system arch

### DIFF
--- a/Makefile.darwin
+++ b/Makefile.darwin
@@ -30,7 +30,7 @@ install.dependencies: install.os install.lima-dependencies install.lima-socket-v
 install.os: $(OS_OUTDIR)/$(FINCH_OS_BASENAME)
 
 $(OS_OUTDIR)/$(FINCH_OS_BASENAME): $(OS_OUTDIR) $(CURDIR)/deps/full-os.conf
-	bash deps/install.sh --output $@ $(CURDIR)/deps/full-os.conf
+	bash deps/install.sh --arch $(ARCH) --output $@ $(CURDIR)/deps/full-os.conf
 
 .PHONY: install.lima-dependencies
 install.lima-dependencies: download.lima-dependencies $(LIMA_OUTDIR)
@@ -40,7 +40,7 @@ install.lima-dependencies: download.lima-dependencies $(LIMA_OUTDIR)
 download.lima-dependencies: $(LIMA_DOWNLOAD_DIR)/$(LIMA_DEPENDENCY_FILE_NAME)
 
 $(LIMA_DOWNLOAD_DIR)/$(LIMA_DEPENDENCY_FILE_NAME): $(LIMA_DOWNLOAD_DIR) $(CURDIR)/deps/lima-bundles.conf
-	bash deps/install.sh --output $@ $(CURDIR)/deps/lima-bundles.conf
+	bash deps/install.sh --arch $(ARCH) --output $@ $(CURDIR)/deps/lima-bundles.conf
 
 .PHONY: install.lima-socket-vmnet
 install.lima-socket-vmnet:

--- a/Makefile.windows
+++ b/Makefile.windows
@@ -27,7 +27,7 @@ install.dependencies: install.rootfs install.lima
 install.rootfs: $(ROOTFS_OUTPUT_DIR)/$(FINCH_ROOTFS_BASENAME)
 
 $(ROOTFS_OUTPUT_DIR)/$(FINCH_ROOTFS_BASENAME): $(ROOTFS_OUTPUT_DIR) $(CURDIR)/deps/rootfs.conf
-	bash deps/install.sh --output $@ $(CURDIR)/deps/rootfs.conf
+	bash deps/install.sh --arch $(ARCH) --output $@ $(CURDIR)/deps/rootfs.conf
 
 .PHONY: install.lima
 install.lima: lima-exe install.lima-dependencies-wsl2

--- a/deps/install.sh
+++ b/deps/install.sh
@@ -13,6 +13,7 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd -- "${CURRENT_DIR}/.." && pwd)"
 
 file=""
+arch=""
 sources=""
 
 while [[ $# -gt 0 ]]; do
@@ -20,6 +21,11 @@ while [[ $# -gt 0 ]]; do
     --output|-o)
       shift # past argument
       file=$1
+      shift # past value
+      ;;
+    --arch|-a)
+      shift # past argument
+      arch=$1
       shift # past value
       ;;
     --*|-*)
@@ -44,7 +50,6 @@ artifact=""
 digest=""
 url="${ARTIFACT_BASE_URL}"
 
-arch="$(uname -m)"
 case "${arch}" in
   "arm64")
     if [[ -z "$AARCH64_ARTIFACT" ]]; then


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
We can't cross-build if the arch is determined by `uname` at runtime. Instead, pass use `ARCH`.

*Testing done:*


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.