### PR TITLE
ci: ignore OS image artifacts in update workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ wingit-temp/
 *.idea
 *.DS_Store
 *.bak
+**/*.qcow2
 **/*.tar.gz
 .vscode/
 **/node_modules


### PR DESCRIPTION
Issue #, if available:
Update dependencies workflow is failing due to artifacts sizing. Artifacts are pulled in CI to validate SHASUMs are correct.

*Description of changes:*
 This change adds OS images to gitignore.

*Testing done:*
Ran update scripts locally and validated added entry to gitignore would exclude images.

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.