### PR TITLE
build: add finch daemon

### DIFF
--- a/.github/workflows/submodulesync.yaml
+++ b/.github/workflows/submodulesync.yaml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Update sub modules
+      - name: Update submodules
         run: |
           git submodule update --remote
           # pin submodule to a commit, https://github.com/lima-vm/lima/commit/bd7442e34ebdccb4945828a007b5d102781bea92
@@ -24,6 +24,11 @@ jobs:
           TAG=`cd src/lima && git describe --tags $(git rev-list --tags --max-count=1)`
           echo "Pulling changes from release: $TAG"
           (cd src/lima && git checkout $TAG)
+          # finch-daemon
+          (cd src/finch-daemon && git fetch --tags)
+          FINCH_DAEMON_TAG=`cd src/finch-daemon && git describe --tags $(git rev-list --tags --max-count=1)`
+          echo "Pulling changes from release: $FINCH_DAEMON_TAG"
+          (cd src/finch-daemon && git checkout $FINCH_DAEMON_TAG)
 
       - name: Create PR
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "src/socket_vmnet"]
 	path = src/socket_vmnet
 	url = https://github.com/lima-vm/socket_vmnet
+[submodule "src/finch-daemon"]
+	path = src/finch-daemon
+	url = https://github.com/runfinch/finch-daemon.git

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ download-sources:
 $(FINCH_DAEMON_OUTDIR)/finch-daemon: $(OUTPUT_DIRECTORIES)
 	git submodule update --init --recursive src/finch-daemon
 	cd src/finch-daemon && git clean -f -d
-	cd src/finch-daemon && STATIC=1 GOOS=$(BUILD_OS) GOARCH=$(ARCH) "$(MAKE)"
+	cd src/finch-daemon && STATIC=1 GOOS=linux GOARCH=$(ARCH) "$(MAKE)"
 	cp src/finch-daemon/bin/finch-daemon $@
 
 .PHONY: install

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ clean:
 	-@rm -rf $(OUTDIR) 2>/dev/null || true
 	-@rm -rf $(DOWNLOAD_DIR) 2>/dev/null || true
 	-@rm ./*.tar.gz 2>/dev/null || true
+	-@cd src/finch-daemon && make clean 2>/dev/null || true
 
 .PHONY: test-e2e
 test-e2e: $(LIMA_TEMPLATE_OUTDIR)/fedora.yaml

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ all: install.dependencies
 # install.dependencies is a make target defined by the respective platform makefile
 # pull the required finch core dependencies for the platform.
 .PHONY: install.dependencies
+install.dependencies: $(OUTDIR)/finch-daemon
 
 # Rootfs required for Windows, require full OS for Mac
 FINCH_IMAGE_LOCATION ?=
@@ -38,6 +39,12 @@ $(OUTPUT_DIRECTORIES):
 .PHONY: download-sources
 download-sources:
 	./bin/download-sources.pl
+
+$(OUTDIR)/finch-daemon:
+	git submodule update --init --recursive src/finch-daemon
+	cd src/finch-daemon && git clean -f -d
+	cd src/finch-daemon && STATIC=1 GOOS=$(BUILD_OS) GOARCH=$(ARCH) "$(MAKE)"
+	cp src/finch-daemon/bin/finch-daemon $@
 
 .PHONY: install
 install: uninstall

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,14 @@ else
 include Makefile.darwin
 endif
 
+# transform some common results of uname -m to be compatible with Go
+GOARCH ?= $(ARCH)
+ifeq ($(GOARCH), x86_64)
+GOARCH = amd64
+else ifeq ($(GOARCH), aarch64)
+GOARCH = arm64
+endif
+
 $(OUTPUT_DIRECTORIES):
 	@mkdir -p $@
 
@@ -44,7 +52,7 @@ download-sources:
 $(FINCH_DAEMON_OUTDIR)/finch-daemon: $(OUTPUT_DIRECTORIES)
 	git submodule update --init --recursive src/finch-daemon
 	cd src/finch-daemon && git clean -f -d
-	cd src/finch-daemon && STATIC=1 GOOS=linux GOARCH=$(ARCH) "$(MAKE)"
+	cd src/finch-daemon && STATIC=1 GOOS=linux GOARCH=$(GOARCH) "$(MAKE)"
 	cp src/finch-daemon/bin/finch-daemon $@
 
 .PHONY: install

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,12 @@ OUTDIR ?= $(CURDIR)/_output
 DOWNLOAD_DIR := $(CURDIR)/downloads
 LIMA_DOWNLOAD_DIR := $(DOWNLOAD_DIR)/dependencies
 LIMA_OUTDIR ?= $(OUTDIR)/lima
+FINCH_DAEMON_OUTDIR ?= $(OUTDIR)/finch-daemon
 UNAME := $(shell uname -m)
 ARCH ?= $(UNAME)
 BUILD_TS := $(shell date +%s)
 
-OUTPUT_DIRECTORIES=$(OUTDIR) $(DOWNLOAD_DIR) $(LIMA_DOWNLOAD_DIR) $(LIMA_OUTDIR)
+OUTPUT_DIRECTORIES=$(OUTDIR) $(DOWNLOAD_DIR) $(LIMA_DOWNLOAD_DIR) $(LIMA_OUTDIR) $(FINCH_DAEMON_OUTDIR)
 
 LIMA_DEPENDENCY_FILE_NAME ?= lima-and-qemu.tar.gz
 .DEFAULT_GOAL := all
@@ -20,7 +21,7 @@ all: install.dependencies
 # install.dependencies is a make target defined by the respective platform makefile
 # pull the required finch core dependencies for the platform.
 .PHONY: install.dependencies
-install.dependencies: $(OUTDIR)/finch-daemon
+install.dependencies: $(FINCH_DAEMON_OUTDIR)/finch-daemon
 
 # Rootfs required for Windows, require full OS for Mac
 FINCH_IMAGE_LOCATION ?=
@@ -40,7 +41,7 @@ $(OUTPUT_DIRECTORIES):
 download-sources:
 	./bin/download-sources.pl
 
-$(OUTDIR)/finch-daemon:
+$(FINCH_DAEMON_OUTDIR)/finch-daemon: $(OUTPUT_DIRECTORIES)
 	git submodule update --init --recursive src/finch-daemon
 	cd src/finch-daemon && git clean -f -d
 	cd src/finch-daemon && STATIC=1 GOOS=$(BUILD_OS) GOARCH=$(ARCH) "$(MAKE)"


### PR DESCRIPTION
Issue #, if available:

### Description of changes
1. Adds a finch-core as a submodule, and adds building it to the `install.dependencies` target
2. Adds finch-core to the submodulesync workflow so that the latest tag is always used


*Testing done:*


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.