### PR TITLE
fix: codesign make target was removed

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -145,7 +145,7 @@ jobs:
       - name: Create Ventura limactl tarball
         working-directory: src/lima
         run: |
-          make clean && make exe codesign
+          make clean && make exe
           tar cfz limactl.ventura.arm64.tar.gz -C _output/bin limactl
 
       - name: Upload Ventura build
@@ -175,7 +175,7 @@ jobs:
       - name: Create Ventura limactl tarball
         working-directory: src/lima
         run: |
-          make clean && make exe codesign
+          make clean && make exe
           tar cfz limactl.ventura.x86_64.tar.gz -C _output/bin limactl
 
       - name: Upload Ventura build


### PR DESCRIPTION
Issue #, if available:

Lima's codesign make target was removed, causing the [build workflow to fail](https://github.com/runfinch/finch-core/actions/runs/11862845247/job/33063098662#step:5:167):
```
make: *** No rule to make target `codesign'.  Stop.
```

## Description of changes
Removed the codesign target since its former use is now embeded in the exe target.

## Testing done


- [x] I've reviewed the guidance in CONTRIBUTING.md


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.