### PR TITLE
ci: use separate pull request branch per update workflow

### DIFF
--- a/.github/workflows/submodulesync.yaml
+++ b/.github/workflows/submodulesync.yaml
@@ -37,3 +37,4 @@ jobs:
           commit-message: bump submodules
           signoff: true
           title: 'build(deps): Bump submodules'
+          branch: create-pull-request/update-submodules

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -44,3 +44,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           signoff: true
           title: 'build(deps): Bump finch dependencies'
+          branch: create-pull-request/bump-finch-dependencies


### PR DESCRIPTION
Issue #, if available:
#434 

*Description of changes:*
This change updates the update workflows to use their own PR branch.

*Testing done:*


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.