### PR TITLE
ci: add macOS ARM to install dependencies GHA CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, windows-2022]
+        os: [macos-13, macos-13-xlarge, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
Issue #, if available:
For macOS x86 and Windows, we are testing the Finch-core dependencies can be downloaded and installed.

*Description of changes:*
This change adds the same verification for macOS ARM.


*Testing done:*
CI says it all

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.