### PR TITLE
ci: refactor platform specific GHA CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, windows-2022]
+        os: [macos-13, macos-13-xlarge, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code

--- a/.github/workflows/macos-ci.yaml
+++ b/.github/workflows/macos-ci.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: macOS CI
 on:
   push:
     branches:
@@ -9,10 +9,14 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - "**.md"
-      - "contrib/**"
-      - "Dockerfile"
+    paths:
+      - .github/workflows/macos-ci.yaml
+      - deps/full-os.conf
+      - deps/lima.conf
+      - e2e/**
+      - lima-template/**
+      - Makefile
+      - Makefile.darwin
   workflow_dispatch:
 
 concurrency:
@@ -21,14 +25,14 @@ concurrency:
 
 jobs:
   install-dependencies:
-    # This is a spot check for make install.dependencies on macOS and Windows platforms.
+    # This is a spot check for make install.dependencies on macOS x86/ARM platforms.
     # Finch-core provides the core dependencies needed to run Finch such as the base OS
     # image, rootfs, and Lima bundle. Validate the mechanism used to install the core
-    # dependencies works on the respective platforms.
+    # dependencies works on macOS.
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-13-xlarge, windows-2022]
+        os: [macos-13, macos-13-xlarge]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code

--- a/.github/workflows/windows-ci.yaml
+++ b/.github/workflows/windows-ci.yaml
@@ -1,0 +1,49 @@
+name: Windows CI
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
+      - "src/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/windows-ci.yaml
+      - deps/rootfs.conf
+      - Makefile
+      - Makefile.windows
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  install-dependencies:
+    # This is a spot check for make install.dependencies on Windows platform.
+    # Finch-core provides the core dependencies needed to run Finch such as the base OS
+    # image, rootfs, and Lima bundle. Validate the mechanism used to install the core
+    # dependencies works on Windows.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2022]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          submodules: true
+      - name: Setup go
+        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        with:
+          go-version-file: e2e/go.mod
+          cache-dependency-path: e2e/go.sum
+      - name: Install platform dependencies
+        run: make install.dependencies
+      - name: Clean up dependencies
+        run: make clean


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
This change refactors the GitHub Actions CI to split macOS and Windows verification such that macOS tests run only when its files change and vice-versa for Windows. The benefit is reduced contention for runners when pushing platform pull requests for Windows and macOS.

*Testing done:*

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.