### PR TITLE
ci: fix dependabot configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -16,7 +16,8 @@ updates:
     include: "scope"
 - package-ecosystem: "gomod"
   directory: "/rootfs/cosign"
-  dependency-type: direct
+  allow:
+    dependency-type: direct
   schedule:
     interval: "daily"
   commit-message:


### PR DESCRIPTION
Issue #, if available:
https://github.com/runfinch/finch-core/pull/478 introduced a mechanism for dependabot to open update PR's for cosign. The configuration is incorrect.

See https://github.com/runfinch/finch-core/runs/35000416717

Documentation: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#dependency-type-allow

*Description of changes:*
This change updates the dependabot configuration for direct dependencies only. i.e. cosign itself.

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.