### PR TITLE
ci: run macos CI on lima bundle updates

### DIFF
--- a/.github/workflows/macos-ci.yaml
+++ b/.github/workflows/macos-ci.yaml
@@ -13,7 +13,7 @@ on:
       - .github/workflows/macos-ci.yaml
       - deps/container-runtime-full-archive.conf
       - deps/full-os.conf
-      - deps/lima.conf
+      - deps/lima-bundles.conf
       - e2e/**
       - lima-template/**
       - Makefile


### PR DESCRIPTION
Issue #, if available:
#490 did not run macOS CI for the lima update.

*Description of changes:*
This change fixes macOS CI to run on lima bundles update.

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.