### PR TITLE
ci: run ci on socket_vmnet submodule updates

### DIFF
--- a/.github/workflows/macos-ci.yaml
+++ b/.github/workflows/macos-ci.yaml
@@ -16,6 +16,7 @@ on:
       - deps/lima-bundles.conf
       - e2e/**
       - lima-template/**
+      - src/socket_vmnet/**
       - Makefile
       - Makefile.darwin
   workflow_dispatch:


### PR DESCRIPTION
Issue #, if available:
Regression introduced by #471

*Description of changes:*
This change adds src/socket_vmnet git submodule to the allowlist for macOS CI.

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.