### PR TITLE
fix: Skip audit and audit-rules installation in rootfs for Windows WSL2

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -33,7 +33,9 @@ RUN dnf group install -y cloud-server-environment --exclude=plymouth* \
     --exclude=firewalld* \
     --exclude=grub* \
     --exclude=dracut* \
-    --exclude=shim-*
+    --exclude=shim-* \
+    --exclude=audit \
+    --exclude=audit-rules
 
 # install packages needed by Lima
 RUN dnf install -y \


### PR DESCRIPTION
Fixes #553 

*Description of changes:*

Exclude `audit` and `audit-rules` package during group install.

They are excluded by exact name, because there are packages in groupinstall which requires `audit-libs`.

*Testing done:*

I uninstalled these packages in Lima using dnf command and restarted system, so, systemd would startup w/o degradation.


- [ ] I've reviewed the guidance in CONTRIBUTING.md

Can't find this file in this repo.


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.