### PR TITLE
ci: run CI on Git submodule update

### DIFF
--- a/.github/workflows/macos-ci.yaml
+++ b/.github/workflows/macos-ci.yaml
@@ -11,12 +11,12 @@ on:
       - main
     paths:
       - .github/workflows/macos-ci.yaml
+      - .gitmodules
       - deps/container-runtime-full-archive.conf
       - deps/full-os.conf
       - deps/lima-bundles.conf
       - e2e/**
       - lima-template/**
-      - src/socket_vmnet/**
       - Makefile
       - Makefile.darwin
   workflow_dispatch:

--- a/.github/workflows/windows-ci.yaml
+++ b/.github/workflows/windows-ci.yaml
@@ -11,6 +11,7 @@ on:
       - main
     paths:
       - .github/workflows/windows-ci.yaml
+      - .gitmodules
       - deps/rootfs.conf
       - Makefile
       - Makefile.windows


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
This change adds .gitmodules to both the macOS/Windows CI for changes to Git submodules.

*Testing done:*


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.