### PR TITLE
chore: update fedora OS to 41

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.4
 
-FROM public.ecr.aws/docker/library/fedora:40 as build
+FROM public.ecr.aws/docker/library/fedora:41 as build
 
 WORKDIR /work
 
@@ -21,7 +21,7 @@ RUN cosign verify-blob \
     --cert-oidc-issuer https://accounts.google.com \
     cosign-${COSIGN_VERSION}-1.x86_64.rpm
 
-FROM public.ecr.aws/docker/library/fedora:40
+FROM public.ecr.aws/docker/library/fedora:41
 
 WORKDIR /work
 


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Fedora 40 got deprecated, updating to fedora 41.

*Testing done:*


- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.