### PR TITLE
fix: qemu and build issues

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   macos-arm64-build:
-    runs-on: [self-hosted, macos, arm64, 12, release]
+    runs-on: [self-hosted, macos, arm64, "13", release]
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: 1.22.x
+          go-version-file: e2e/go.mod
 
       - name: Install dependencies
         # QEMU:      required by Lima itself
@@ -76,7 +76,7 @@ jobs:
           if-no-files-found: error
 
   macos-x86-build:
-    runs-on: [self-hosted, macos, amd64, 12, release]
+    runs-on: [self-hosted, macos, amd64, "13", release]
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -90,7 +90,7 @@ jobs:
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: 1.22.x
+          go-version-file: e2e/go.mod
 
       - name: Install dependencies
         # QEMU:      required by Lima itself
@@ -126,7 +126,7 @@ jobs:
           if-no-files-found: error
 
   macos-arm64-ventura-build:
-    runs-on: [self-hosted, macos, arm64, 13, release]
+    runs-on: [self-hosted, macos, arm64, "13", release]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -140,7 +140,7 @@ jobs:
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: 1.22.x
+          go-version-file: e2e/go.mod
 
       - name: Create Ventura limactl tarball
         working-directory: src/lima
@@ -156,7 +156,7 @@ jobs:
           if-no-files-found: error
 
   macos-x86_64-ventura-build:
-    runs-on: [self-hosted, macos, amd64, 13, release]
+    runs-on: [self-hosted, macos, amd64, "13", release]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -170,7 +170,7 @@ jobs:
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: 1.22.x
+          go-version-file: e2e/go.mod
 
       - name: Create Ventura limactl tarball
         working-directory: src/lima

--- a/bin/lima-and-qemu.pl
+++ b/bin/lima-and-qemu.pl
@@ -66,7 +66,7 @@ for my $template (@ARGV) {
     my $config = "$templatedir/$template.yaml", ;
     die "Config $config not found" unless -f $config;
     system("limactl delete -f $template") if -d "$ENV{HOME}/.lima/$template";
-    system("limactl start --tty=false $config");
+    system("limactl start --tty=false --vm-type=qemu $config");
     system("limactl shell $template uname");
     system("limactl stop $template");
     system("limactl delete $template");

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,8 +1,6 @@
 module finch-core
 
-go 1.23.0
-
-toolchain go1.24.1
+go 1.24.5
 
 require (
 	github.com/onsi/ginkgo/v2 v2.23.4

--- a/lima-template/fedora.yaml
+++ b/lima-template/fedora.yaml
@@ -29,6 +29,10 @@ memory: "4GiB"
 # 🟢 Builtin default: "100GiB"
 disk: null
 
+# 9p is broken in Linux v6.9, v6.10, and v6.11 (used by Fedora 41).
+# The issue was fixed in Linux v6.12-rc5 (https://github.com/torvalds/linux/commit/be2ca38).
+mountType: reverse-sshfs
+
 # Expose host directories to the guest, the mount point might be accessible from all UIDs in the guest
 # 🟢 Builtin default: null (Mount nothing)
 # 🔵 This file: Mount the home as read-only, /tmp/lima as writable


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Upgrades the macOS version used to package Lima binaries (**this will stop Finch from working on macOS 12**)
- Explicitly use qemu virtualization so that we package the QEMU binaries
- Upgrades the go.mod version
- Fixes an issue with the QEMU e2e tests due to a kernel bug with Lima's default `mountType`

*Testing done:*


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.