### PR TITLE
ci: use intermediate env variable for nerdctl tag override in workflow

### DIFF
--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -71,16 +71,17 @@ jobs:
 
       - name: Fetch tag for latest release
         id: fetch-tag
+        env:
+          OVERRIDE_TAG: ${{ github.event.inputs.nerdctl_tag_override }}
         run: |
-          tag="$(git tag --sort=-version:refname | head -n 1)"
-          echo "Latest tag is ${tag}"
-
-          if [[ -n "${{ github.event.inputs.nerdctl_tag_override }}" ]]; then
-            tag="${{ github.event.inputs.nerdctl_tag_override }}"
-            echo "Override tag: ${tag}"
+          if [ -n "$OVERRIDE_TAG" ]; then
+            echo "tag=$OVERRIDE_TAG" >> $GITHUB_OUTPUT
+            echo "Override tag: $OVERRIDE_TAG"
+          else
+            latest_tag="$(git tag --sort=-version:refname | head -n 1)"
+            echo "tag=$latest_tag" >> $GITHUB_OUTPUT
+            echo "Latest tag is ${latest_tag}"
           fi
-
-          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
 
   update-container-runtime-full-archive:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Issue #, if available:
This PR improves the security of the `update-dependencies.yaml` file. Following the best practices mentioned in the [github actions security hardening guidelines](https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable)


*Description of changes:*
- Use an intermediate variable for user inputs to prevent script injection


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.