### PR TITLE
fix: apply lima patch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Make and release deps
         run: |
-          (cd src/lima && git clean -f -d)
+          (cd src/lima && git clean -f -d && git am ../patches/lima/*.patch)
           make -C src/lima PREFIX=/opt/homebrew all install
           ./bin/lima-and-qemu.pl
           mv src/lima/lima-and-qemu.tar.gz src/lima/lima-and-qemu.macos-aarch64.tar.gz
@@ -112,7 +112,7 @@ jobs:
 
       - name: Make and release deps
         run: |
-          (cd src/lima && git clean -f -d)
+          (cd src/lima && git clean -f -d && git am ../patches/lima/*.patch)
           make -C src/lima PREFIX=/usr/local all install
           ./bin/lima-and-qemu.pl
           mv src/lima/lima-and-qemu.tar.gz src/lima/lima-and-qemu.macos-x86_64.tar.gz
@@ -145,7 +145,7 @@ jobs:
       - name: Create Ventura limactl tarball
         working-directory: src/lima
         run: |
-          make clean && make exe
+          make clean && git am ../patches/lima/*.patch && make exe
           tar cfz limactl.ventura.arm64.tar.gz -C _output/bin limactl
 
       - name: Upload Ventura build
@@ -175,7 +175,7 @@ jobs:
       - name: Create Ventura limactl tarball
         working-directory: src/lima
         run: |
-          make clean && make exe
+          make clean && git am ../patches/lima/*.patch && make exe
           tar cfz limactl.ventura.x86_64.tar.gz -C _output/bin limactl
 
       - name: Upload Ventura build

--- a/src/patches/lima/0001-fix-make-qemu-convertToRaw-to-handle-symlinks.patch
+++ b/src/patches/lima/0001-fix-make-qemu-convertToRaw-to-handle-symlinks.patch
@@ -1,0 +1,29 @@
+From bf4167ef86259f2339507b35bd4d54119b4018bc Mon Sep 17 00:00:00 2001
+From: Justin Alvarez <alvajus@amazon.com>
+Date: Wed, 3 Sep 2025 13:28:38 -0400
+Subject: [PATCH 1/1] fix: make qemu convertToRaw to handle symlinks
+
+Signed-off-by: Justin Alvarez <alvajus@amazon.com>
+---
+ pkg/qemuimgutil/qemuimgutil.go | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/pkg/qemuimgutil/qemuimgutil.go b/pkg/qemuimgutil/qemuimgutil.go
+index 8872eb56..6ac7b041 100644
+--- a/pkg/qemuimgutil/qemuimgutil.go
++++ b/pkg/qemuimgutil/qemuimgutil.go
+@@ -123,6 +123,11 @@ func convertToRaw(source, dest string) error {
+ 	if err := execQemuImgConvert(source, tempFile); err != nil {
+ 		return err
+ 	}
++	
++	realDest, _ := os.Readlink(dest)
++	if realDest != "" && realDest != dest {
++		dest = realDest
++	}
+ 
+ 	return os.Rename(tempFile, dest)
+ }
+-- 
+2.39.5 (Apple Git-154)
+


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Adds a patch to Lima which fixes a discrepancy between Lima's "native" disk utility and it's qemu-img based disk utility. Keeping this patch in finch-core is temporary, and we will work to upstream the change as it seems like a bug. Upstreaming will require more care, as it will need e2e/integ tests.

*Testing done:*
- Ran the build from this branch (https://github.com/runfinch/finch-core/actions/runs/17442933559) and verified that we're seeing the expected behavior w.r.t. symlinks

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.