### PR TITLE
fix(ci): don't update lima bundle on PR

### DIFF
--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -27,6 +27,7 @@ permissions:
 
 jobs:
   update-lima-bundle:
+    if: github.event_name != 'pull_request' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     permissions:
@@ -51,7 +52,6 @@ jobs:
         run: bash bin/update-lima-bundles.sh -d ${{ secrets.DEPENDENCY_BUCKET_NAME }}
 
       - name: create PR
-        if: github.event_name != 'pull_request'
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           # A Personal Access Token instead of the default `GITHUB_TOKEN` is required


### PR DESCRIPTION

Issue #, if available:

*Description of changes:*
Only run this script on non-PR
Also ignore pushes from dependabot per convention elsewhere

*Testing done:*


- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.