### PR TITLE
fix(ci): fix ecr clean image workflow for immutable latest-{arch} tags

### DIFF
--- a/.github/workflows/push-container-image.yaml
+++ b/.github/workflows/push-container-image.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           # Artifacts follow the name "finch-al2023-os-image-arm64-<run_id>.qcow2"
           run_id=$(grep 'AARCH64_ARTIFACT=' deps/full-os.conf | grep -oP '\d+(?=\.qcow2)')
-          version=$(date -u +'%Y.%-m.%-d')-build-${run_id}
+          version=0.${run_id}.0+${{ matrix.arch }}-with-kernel
           echo "run_id=${run_id}" >> $GITHUB_OUTPUT
           echo "version=${version}" >> $GITHUB_OUTPUT
       - name: Configure AWS credentials
@@ -56,13 +56,21 @@ jobs:
         run: |
           skopeo copy \
             "oci-archive:container-with-kernel-image.tar" \
-            docker://"${{ secrets.ROOTFS_IMAGE_ECR_REPOSITORY_NAME }}:${{ steps.vars.outputs.version }}-${{ matrix.arch }}-with-kernel"
+            docker://"${{ secrets.ROOTFS_IMAGE_ECR_REPOSITORY_NAME }}:${{ steps.vars.outputs.version }}"
       - name: Delete old ECR images
         run: |
           bash bin/clean-ecr-images.sh \
             --repo "${{ secrets.ROOTFS_IMAGE_ECR_REPOSITORY_NAME }}" \
             --arch "${{ matrix.arch }}" \
-            --keep-tag "${{ steps.vars.outputs.version }}-${{ matrix.arch }}-with-kernel"
+            --keep-tag "${{ steps.vars.outputs.version }}"
+      # Because tags are immutable in ECR, we have to delete the existing latest-{arch} tag first
+      # Note that this does not actually delete the image because the image in question
+      # has two tags, e.g.: x86-64-with-kernel-22922664487, latest-x86-64
+      - name: Delete existing latest tag from ECR
+        run: |
+          aws ecr batch-delete-image \
+            --repository-name "${{ secrets.ROOTFS_IMAGE_ECR_REPOSITORY_NAME }}" \
+            --image-ids imageTag="latest-${{ matrix.arch }}"
       - name: Tag container image as latest
         run: |
           skopeo copy \

--- a/bin/clean-ecr-images.sh
+++ b/bin/clean-ecr-images.sh
@@ -39,7 +39,8 @@ arch_digests=$(echo "${all_images}" | \
     | select(.imageTags // [] | any(contains($arch)))
     | .imageDigest')
 
-# Find the digest that has the latest-$arch tag (to keep)
+# Find the digest of the image that has the latest-$arch tag (to keep)
+# This is the image that the current prod finch version has shipped
 keep_digest=$(echo "${all_images}" | \
   jq -r --arg tag "${latest_tag}" '.imageDetails[]
     | select(.imageTags // [] | any(. == $tag))


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Date in tags is a bad idea, change it to 0.\<runid\>.0+{arch}-with-kernel.
- Tags are immutable in finch rootfs repo in ECR so delete the latest-{arch} tag first because tagging the current image.

*Testing done:*


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.