### PR TITLE
fix(ci): build QEMU from source and auto-update deps verification

### DIFF
--- a/.github/workflows/build-lima-and-qemu.yaml
+++ b/.github/workflows/build-lima-and-qemu.yaml
@@ -50,7 +50,13 @@ jobs:
         # fs_usage:  built-in macOS tool used to capture opened files by limactl and qemu
 
         run: |
-          # uninstall any previous qemu installations and install pinned qemu version from qemu.conf
+          # upgrade all packages first to ensure consistent dependency versions
+          brew update
+          brew install bash coreutils
+          brew install autoconf automake
+          brew upgrade
+
+          # install pinned qemu AFTER brew upgrade to avoid shared library mismatches
           brew uninstall --force qemu
           source ./deps/qemu.conf
           echo "Installing pinned qemu version: $QEMU_VERSION"
@@ -58,12 +64,7 @@ jobs:
           mkdir -p $HOMEBREW_LOCAL_REPO
           rm -f $HOMEBREW_LOCAL_REPO/qemu.rb
           curl -L -o $HOMEBREW_LOCAL_REPO/qemu.rb https://raw.githubusercontent.com/Homebrew/homebrew-core/${QEMU_FORMULA_GH_COMMIT}/Formula/q/qemu.rb
-          brew install homebrew/local/qemu
-
-          brew update
-          brew install bash coreutils
-          brew install autoconf automake
-          brew upgrade
+          brew install --build-from-source homebrew/local/qemu
         shell: zsh {0}
 
       - name: Make and release deps
@@ -93,6 +94,14 @@ jobs:
           name: lima-and-qemu.macos-arm64
           path: ./src/lima/lima-and-qemu.macos*
           if-no-files-found: error
+
+      - name: Upload verification file ARM64
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: always()
+        with:
+          name: deps-verification-arm64
+          path: ./deps-verification-arm64.generated.txt
+          if-no-files-found: warn
 
       - name: Upload dependency mapping ARM64
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -140,7 +149,13 @@ jobs:
         # fs_usage:  built-in macOS tool used to capture opened files by limactl and qemu
 
         run: |
-          # uninstall any previous qemu installations and install pinned qemu version from qemu.conf
+          # upgrade all packages first to ensure consistent dependency versions
+          brew update
+          brew install bash coreutils
+          brew install autoconf automake
+          brew upgrade
+
+          # install pinned qemu AFTER brew upgrade to avoid shared library mismatches
           brew uninstall --force qemu
           source ./deps/qemu.conf
           echo "Installing pinned qemu version: $QEMU_VERSION"
@@ -148,12 +163,7 @@ jobs:
           mkdir -p $HOMEBREW_LOCAL_REPO
           rm -f $HOMEBREW_LOCAL_REPO/qemu.rb
           curl -L -o $HOMEBREW_LOCAL_REPO/qemu.rb https://raw.githubusercontent.com/Homebrew/homebrew-core/${QEMU_FORMULA_GH_COMMIT}/Formula/q/qemu.rb
-          brew install homebrew/local/qemu
-          
-          brew update
-          brew install bash coreutils
-          brew install autoconf automake
-          brew upgrade
+          brew install --build-from-source homebrew/local/qemu
         shell: zsh {0}
 
       - name: Make and release deps
@@ -183,6 +193,14 @@ jobs:
           name: lima-and-qemu.macos-x86
           path: ./src/lima/lima-and-qemu.macos*
           if-no-files-found: error
+
+      - name: Upload verification file x86
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: always()
+        with:
+          name: deps-verification-x86
+          path: ./deps-verification-x86.generated.txt
+          if-no-files-found: warn
 
       - name: Upload dependency mapping x86_64
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -295,3 +313,51 @@ jobs:
           aws s3 cp ./build/ s3://${{ secrets.DEPENDENCY_BUCKET_NAME }}/aarch64/ --recursive --exclude "*" --include "lima-and-qemu.macos-aarch64.${timestamp}.tar.gz*"
           aws s3 cp ./build/ s3://${{ secrets.DEPENDENCY_BUCKET_NAME }}/x86-64/ --recursive --exclude "*" --include "lima-and-qemu.macos-x86_64.${timestamp}.tar.gz*" 
           aws s3 cp ./build/ s3://${{ secrets.DEPENDENCY_BUCKET_NAME }} --recursive --exclude "*"  --include "dependency-sources.tar.gz"
+
+  update-verification-files:
+    needs: [macos-arm64-build, macos-x86-build]
+    if: always() && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Download verification file ARM64
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: deps-verification-arm64
+          path: .
+        continue-on-error: true
+
+      - name: Download verification file x86
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: deps-verification-x86
+          path: .
+        continue-on-error: true
+
+      - name: Rename generated files
+        run: |
+          [ -f deps-verification-arm64.generated.txt ] && mv deps-verification-arm64.generated.txt deps-verification-arm64.txt
+          [ -f deps-verification-x86.generated.txt ] && mv deps-verification-x86.generated.txt deps-verification-x86.txt
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          signoff: true
+          commit-message: "chore: update deps verification files"
+          title: "chore: update deps verification files"
+          body: |
+            Auto-generated update of dependency verification files from
+            [build-lima-and-qemu workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+
+            Please review the dependency changes and merge if expected.
+          branch: chore/update-deps-verification
+          delete-branch: true

--- a/bin/lima-and-qemu.py
+++ b/bin/lima-and-qemu.py
@@ -169,6 +169,15 @@ def run_lima_template(template_name: str, template_yaml: str):
         subprocess.run(f"limactl stop {template_name}", shell=True, check=True)
         subprocess.run(f"limactl delete {template_name}", shell=True, check=True)
     except Exception as ex:
+        home_dir = os.getenv("HOME", "")
+        lima_dir = os.path.join(home_dir, ".lima", template_name)
+        for log in ["ha.stderr.log", "ha.stdout.log", "serial.log"]:
+            log_path = os.path.join(lima_dir, log)
+            if os.path.exists(log_path):
+                print(f"=== {log} ===")
+                with open(log_path) as f:
+                    content = f.read()
+                    print(content[-5000:] if len(content) > 5000 else content)
         raise RuntimeError(f"failed to run lima template '{template_name}'") from ex
 
 def copy_deps(deps: Dict[str, str], arch: Literal[Arch.X86_64, Arch.AARCH64], install_dir: str):
@@ -420,16 +429,29 @@ def parse_fs_usage_log(log_file: str, deps: Dict[str, str], install_dir: str):
 
     os.unlink(log_file)
 
+def _write_verification_file(verification_path: str, deps: Dict[str, str]):
+    with open(verification_path, 'w') as f:
+        for path in sorted(deps.keys()):
+            f.write(f"{path} {deps[path]}\n")
+
 def verify_dependencies(current_deps: Dict[str, str], arch: Literal[Arch.X86_64, Arch.AARCH64], install_dir: str):
     print("=== Dependency Verification ===")
     
     # Determine verification file based on architecture
     verification_file = "deps-verification-x86.txt" if arch == Arch.X86_64 else "deps-verification-arm64.txt"
     verification_path = os.path.join(os.getcwd(), verification_file)
-    
+
+    # Always write the current deps to a generated file for the workflow to pick up
+    generated_file = verification_file.replace(".txt", ".generated.txt")
+    generated_path = os.path.join(os.getcwd(), generated_file)
+    _write_verification_file(generated_path, current_deps)
+    print(f"Wrote current dependencies to {generated_file} ({len(current_deps)} entries)")
+
     if not os.path.isfile(verification_path):
-        print(f"WARNING: Verification file {verification_path} not found. Skipping dependency verification.")
-        return
+        print(f"ERROR: Verification file {verification_path} not found.")
+        print("The verification file should always exist in the repo.")
+        print(f"A generated file has been written to {generated_file} for the workflow to create a PR.")
+        raise RuntimeError(f"Verification file {verification_file} not found!")
     
     print(f"Verifying dependencies against {verification_file} (ignoring version mismatches)...")
     
@@ -519,7 +541,7 @@ def verify_dependencies(current_deps: Dict[str, str], arch: Literal[Arch.X86_64,
     
     if verification_failed:
         print("Dependency verification FAILED!")
-        print("Please review the differences above and update the verification file if the changes are expected.")
+        print("Please review the auto-generated PR with updated verification files.")
         print(f"Verification file: {verification_path}")
         raise RuntimeError("Dependency verification FAILED!")
     else:

--- a/deps-verification-arm64.txt
+++ b/deps-verification-arm64.txt
@@ -1,115 +1,114 @@
-/opt/homebrew/libexec/lima/limactl-mcp [6.2M]
-/opt/homebrew/libexec/lima/limactl-url-fedora-rawhide [1.3K]
-/opt/homebrew/Cellar/capstone/5.0.6/lib/libcapstone.5.dylib [6.8M]
-/opt/homebrew/Cellar/capstone/5.0.6/lib/libcapstone.dylib → libcapstone.5.dylib
-/opt/homebrew/Cellar/dtc/1.7.2/lib/libfdt.1.dylib → libfdt.dylib.1.7.2
-/opt/homebrew/Cellar/dtc/1.7.2/lib/libfdt.dylib → libfdt.1.dylib
-/opt/homebrew/Cellar/dtc/1.7.2/lib/libfdt.dylib.1.7.2 [73K]
-/opt/homebrew/Cellar/gettext/0.26/lib/libintl.8.dylib [225K]
-/opt/homebrew/Cellar/gettext/0.26/lib/libintl.dylib → libintl.8.dylib
-/opt/homebrew/Cellar/glib/2.86.0/lib/libgio-2.0.0.dylib [1.8M]
-/opt/homebrew/Cellar/glib/2.86.0/lib/libgio-2.0.dylib → libgio-2.0.0.dylib
-/opt/homebrew/Cellar/glib/2.86.0/lib/libglib-2.0.0.dylib [1.2M]
-/opt/homebrew/Cellar/glib/2.86.0/lib/libglib-2.0.dylib → libglib-2.0.0.dylib
-/opt/homebrew/Cellar/glib/2.86.0/lib/libgmodule-2.0.0.dylib [70K]
-/opt/homebrew/Cellar/glib/2.86.0/lib/libgmodule-2.0.dylib → libgmodule-2.0.0.dylib
-/opt/homebrew/Cellar/glib/2.86.0/lib/libgobject-2.0.0.dylib [364K]
-/opt/homebrew/Cellar/glib/2.86.0/lib/libgobject-2.0.dylib → libgobject-2.0.0.dylib
+/opt/homebrew/Cellar/capstone/5.0.8/lib/libcapstone.5.dylib [6.8M]
+/opt/homebrew/Cellar/capstone/5.0.8/lib/libcapstone.dylib → libcapstone.5.dylib
+/opt/homebrew/Cellar/dtc/1.8.0/lib/libfdt.1.dylib [73K]
+/opt/homebrew/Cellar/dtc/1.8.0/lib/libfdt.dylib → libfdt.1.dylib
+/opt/homebrew/Cellar/gettext/1.0/lib/libintl.8.dylib [225K]
+/opt/homebrew/Cellar/gettext/1.0/lib/libintl.dylib → libintl.8.dylib
+/opt/homebrew/Cellar/glib/2.88.1/lib/libgio-2.0.0.dylib [1.9M]
+/opt/homebrew/Cellar/glib/2.88.1/lib/libgio-2.0.dylib → libgio-2.0.0.dylib
+/opt/homebrew/Cellar/glib/2.88.1/lib/libglib-2.0.0.dylib [1.3M]
+/opt/homebrew/Cellar/glib/2.88.1/lib/libglib-2.0.dylib → libglib-2.0.0.dylib
+/opt/homebrew/Cellar/glib/2.88.1/lib/libgmodule-2.0.0.dylib [70K]
+/opt/homebrew/Cellar/glib/2.88.1/lib/libgmodule-2.0.dylib → libgmodule-2.0.0.dylib
+/opt/homebrew/Cellar/glib/2.88.1/lib/libgobject-2.0.0.dylib [418K]
+/opt/homebrew/Cellar/glib/2.88.1/lib/libgobject-2.0.dylib → libgobject-2.0.0.dylib
 /opt/homebrew/Cellar/gmp/6.3.0/lib/libgmp.10.dylib [442K]
 /opt/homebrew/Cellar/gmp/6.3.0/lib/libgmp.dylib → libgmp.10.dylib
-/opt/homebrew/Cellar/gnutls/3.8.10/lib/libgnutls.30.dylib [1.8M]
-/opt/homebrew/Cellar/gnutls/3.8.10/lib/libgnutls.dylib → libgnutls.30.dylib
-/opt/homebrew/Cellar/jpeg-turbo/3.1.2/lib/libjpeg.8.3.2.dylib [462K]
-/opt/homebrew/Cellar/jpeg-turbo/3.1.2/lib/libjpeg.8.dylib → libjpeg.8.3.2.dylib
-/opt/homebrew/Cellar/jpeg-turbo/3.1.2/lib/libjpeg.dylib → libjpeg.8.dylib
-/opt/homebrew/Cellar/libidn2/2.3.8/lib/libidn2.0.dylib [253K]
+/opt/homebrew/Cellar/gnutls/3.8.13_2/lib/libgnutls.30.dylib [2.3M]
+/opt/homebrew/Cellar/gnutls/3.8.13_2/lib/libgnutls.dylib → libgnutls.30.dylib
+/opt/homebrew/Cellar/jpeg-turbo/3.1.4.1/lib/libjpeg.8.3.2.dylib [478K]
+/opt/homebrew/Cellar/jpeg-turbo/3.1.4.1/lib/libjpeg.8.dylib → libjpeg.8.3.2.dylib
+/opt/homebrew/Cellar/jpeg-turbo/3.1.4.1/lib/libjpeg.dylib → libjpeg.8.dylib
+/opt/homebrew/Cellar/libidn2/2.3.8/lib/libidn2.0.dylib [252K]
 /opt/homebrew/Cellar/libidn2/2.3.8/lib/libidn2.dylib → libidn2.0.dylib
-/opt/homebrew/Cellar/libpng/1.6.50/lib/libpng.dylib → libpng16.dylib
-/opt/homebrew/Cellar/libpng/1.6.50/lib/libpng16.16.dylib [204K]
-/opt/homebrew/Cellar/libpng/1.6.50/lib/libpng16.dylib → libpng16.16.dylib
-/opt/homebrew/Cellar/libslirp/4.9.1/lib/libslirp.0.dylib [164K]
-/opt/homebrew/Cellar/libslirp/4.9.1/lib/libslirp.dylib → libslirp.0.dylib
-/opt/homebrew/Cellar/libssh/0.12.0/lib/libssh.4.11.0.dylib [469K]
-/opt/homebrew/Cellar/libssh/0.12.0/lib/libssh.4.dylib → libssh.4.11.0.dylib
-/opt/homebrew/Cellar/libssh/0.12.0/lib/libssh.dylib → libssh.4.dylib
-/opt/homebrew/Cellar/libtasn1/4.20.0/lib/libtasn1.6.dylib [106K]
-/opt/homebrew/Cellar/libtasn1/4.20.0/lib/libtasn1.dylib → libtasn1.6.dylib
-/opt/homebrew/Cellar/libunistring/1.3/lib/libunistring.5.dylib [1.9M]
-/opt/homebrew/Cellar/libunistring/1.3/lib/libunistring.dylib → libunistring.5.dylib
-/opt/homebrew/Cellar/libusb/1.0.29/lib/libusb-1.0.0.dylib [175K]
-/opt/homebrew/Cellar/libusb/1.0.29/lib/libusb-1.0.dylib → libusb-1.0.0.dylib
-/opt/homebrew/Cellar/lzo/2.10/lib/liblzo2.2.dylib [139K]
+/opt/homebrew/Cellar/libpng/1.6.58/lib/libpng.dylib → libpng16.dylib
+/opt/homebrew/Cellar/libpng/1.6.58/lib/libpng16.16.dylib [204K]
+/opt/homebrew/Cellar/libpng/1.6.58/lib/libpng16.dylib → libpng16.16.dylib
+/opt/homebrew/Cellar/libslirp/4.9.3/lib/libslirp.0.dylib [170K]
+/opt/homebrew/Cellar/libslirp/4.9.3/lib/libslirp.dylib → libslirp.0.dylib
+/opt/homebrew/Cellar/libssh/0.12.0_1/lib/libssh.4.11.0.dylib [525K]
+/opt/homebrew/Cellar/libssh/0.12.0_1/lib/libssh.4.dylib → libssh.4.11.0.dylib
+/opt/homebrew/Cellar/libssh/0.12.0_1/lib/libssh.dylib → libssh.4.dylib
+/opt/homebrew/Cellar/libtasn1/4.21.0/lib/libtasn1.6.dylib [106K]
+/opt/homebrew/Cellar/libtasn1/4.21.0/lib/libtasn1.dylib → libtasn1.6.dylib
+/opt/homebrew/Cellar/libunistring/1.4.2/lib/libunistring.5.dylib [1.9M]
+/opt/homebrew/Cellar/libunistring/1.4.2/lib/libunistring.dylib → libunistring.5.dylib
+/opt/homebrew/Cellar/libusb/1.0.30/lib/libusb-1.0.0.dylib [176K]
+/opt/homebrew/Cellar/libusb/1.0.30/lib/libusb-1.0.dylib → libusb-1.0.0.dylib
+/opt/homebrew/Cellar/lzo/2.10/lib/liblzo2.2.dylib [140K]
 /opt/homebrew/Cellar/lzo/2.10/lib/liblzo2.dylib → liblzo2.2.dylib
-/opt/homebrew/Cellar/ncurses/6.5/lib/libcurses.dylib → libncurses.dylib
-/opt/homebrew/Cellar/ncurses/6.5/lib/libncurses.6.dylib → libncursesw.6.dylib
-/opt/homebrew/Cellar/ncurses/6.5/lib/libncurses.dylib → libncursesw.6.dylib
-/opt/homebrew/Cellar/ncurses/6.5/lib/libncursesw.6.dylib [342K]
-/opt/homebrew/Cellar/ncurses/6.5/lib/libncursesw.dylib → libncursesw.6.dylib
-/opt/homebrew/Cellar/nettle/3.10.2/lib/libhogweed.6.11.dylib [309K]
-/opt/homebrew/Cellar/nettle/3.10.2/lib/libhogweed.6.dylib → libhogweed.6.11.dylib
-/opt/homebrew/Cellar/nettle/3.10.2/lib/libhogweed.dylib → libhogweed.6.11.dylib
-/opt/homebrew/Cellar/nettle/3.10.2/lib/libnettle.8.11.dylib [326K]
-/opt/homebrew/Cellar/nettle/3.10.2/lib/libnettle.8.dylib → libnettle.8.11.dylib
-/opt/homebrew/Cellar/nettle/3.10.2/lib/libnettle.dylib → libnettle.8.11.dylib
-/opt/homebrew/Cellar/openssl@3/3.5.2/lib/libcrypto.3.dylib [4.5M]
-/opt/homebrew/Cellar/openssl@3/3.5.2/lib/libcrypto.dylib → libcrypto.3.dylib
-/opt/homebrew/Cellar/p11-kit/0.25.8/lib/libp11-kit.0.dylib [1.4M]
-/opt/homebrew/Cellar/p11-kit/0.25.8/lib/libp11-kit.dylib → libp11-kit.0.dylib
-/opt/homebrew/Cellar/p11-kit/0.25.8/lib/p11-kit-proxy.dylib → libp11-kit.0.dylib
-/opt/homebrew/Cellar/pcre2/10.46/lib/libpcre2-8.0.dylib [567K]
-/opt/homebrew/Cellar/pcre2/10.46/lib/libpcre2-8.dylib → libpcre2-8.0.dylib
-/opt/homebrew/Cellar/pixman/0.46.4/lib/libpixman-1.0.dylib [611K]
+/opt/homebrew/Cellar/ncurses/6.6/lib/libcurses.dylib → libncurses.dylib
+/opt/homebrew/Cellar/ncurses/6.6/lib/libncurses.6.dylib → libncursesw.6.dylib
+/opt/homebrew/Cellar/ncurses/6.6/lib/libncurses.dylib → libncursesw.6.dylib
+/opt/homebrew/Cellar/ncurses/6.6/lib/libncursesw.6.dylib [342K]
+/opt/homebrew/Cellar/ncurses/6.6/lib/libncursesw.dylib → libncursesw.6.dylib
+/opt/homebrew/Cellar/nettle/4.0/lib/libhogweed.7.0.dylib [290K]
+/opt/homebrew/Cellar/nettle/4.0/lib/libhogweed.7.dylib → libhogweed.7.0.dylib
+/opt/homebrew/Cellar/nettle/4.0/lib/libhogweed.dylib → libhogweed.7.0.dylib
+/opt/homebrew/Cellar/nettle/4.0/lib/libnettle.9.0.dylib [327K]
+/opt/homebrew/Cellar/nettle/4.0/lib/libnettle.9.dylib → libnettle.9.0.dylib
+/opt/homebrew/Cellar/nettle/4.0/lib/libnettle.dylib → libnettle.9.0.dylib
+/opt/homebrew/Cellar/openssl@3/3.6.2/lib/libcrypto.3.dylib [4.6M]
+/opt/homebrew/Cellar/openssl@3/3.6.2/lib/libcrypto.dylib → libcrypto.3.dylib
+/opt/homebrew/Cellar/p11-kit/0.26.2/lib/libp11-kit.0.dylib [1.5M]
+/opt/homebrew/Cellar/p11-kit/0.26.2/lib/libp11-kit.dylib → libp11-kit.0.dylib
+/opt/homebrew/Cellar/p11-kit/0.26.2/lib/p11-kit-proxy.dylib → libp11-kit.0.dylib
+/opt/homebrew/Cellar/pcre2/10.47_1/lib/libpcre2-8.0.dylib [578K]
+/opt/homebrew/Cellar/pcre2/10.47_1/lib/libpcre2-8.dylib → libpcre2-8.0.dylib
+/opt/homebrew/Cellar/pixman/0.46.4/lib/libpixman-1.0.dylib [620K]
 /opt/homebrew/Cellar/pixman/0.46.4/lib/libpixman-1.dylib → libpixman-1.0.dylib
-/opt/homebrew/Cellar/qemu/10.1.0/bin
-/opt/homebrew/Cellar/qemu/10.1.0/bin/qemu-img [2.0M]
-/opt/homebrew/Cellar/qemu/10.1.0/bin/qemu-system-aarch64 [29M]
-/opt/homebrew/Cellar/qemu/10.1.0/share/qemu/edk2-aarch64-code.fd [64M]
-/opt/homebrew/Cellar/qemu/10.1.0/share/qemu/efi-virtio.rom [157K]
+/opt/homebrew/Cellar/qemu/10.2.2/bin [ec2-user]
+/opt/homebrew/Cellar/qemu/10.2.2/bin/qemu-img [2.0M]
+/opt/homebrew/Cellar/qemu/10.2.2/bin/qemu-system-aarch64 [29M]
+/opt/homebrew/Cellar/qemu/10.2.2/share/qemu/edk2-aarch64-code.fd [64M]
+/opt/homebrew/Cellar/qemu/10.2.2/share/qemu/efi-virtio.rom [157K]
 /opt/homebrew/Cellar/snappy/1.2.2/lib/libsnappy.1.2.2.dylib [78K]
 /opt/homebrew/Cellar/snappy/1.2.2/lib/libsnappy.1.dylib → libsnappy.1.2.2.dylib
 /opt/homebrew/Cellar/snappy/1.2.2/lib/libsnappy.dylib → libsnappy.1.dylib
 /opt/homebrew/Cellar/vde/2.3.3/lib/libvdeplug.3.dylib [70K]
 /opt/homebrew/Cellar/vde/2.3.3/lib/libvdeplug.dylib → libvdeplug.3.dylib
-/opt/homebrew/Cellar/zstd/1.5.7/lib/libzstd.1.5.7.dylib [654K]
-/opt/homebrew/Cellar/zstd/1.5.7/lib/libzstd.1.dylib → libzstd.1.5.7.dylib
-/opt/homebrew/Cellar/zstd/1.5.7/lib/libzstd.dylib → libzstd.1.dylib
-/opt/homebrew/bin/limactl [28M]
+/opt/homebrew/Cellar/zstd/1.5.7_1/lib/libzstd.1.5.7.dylib [638K]
+/opt/homebrew/Cellar/zstd/1.5.7_1/lib/libzstd.1.dylib → libzstd.1.5.7.dylib
+/opt/homebrew/Cellar/zstd/1.5.7_1/lib/libzstd.dylib → libzstd.1.dylib
+/opt/homebrew/bin/limactl [31M]
 /opt/homebrew/bin/qemu-img [34B]
 /opt/homebrew/bin/qemu-system-aarch64 [45B]
-/opt/homebrew/opt/capstone → ../Cellar/capstone/5.0.6
-/opt/homebrew/opt/dtc → ../Cellar/dtc/1.7.2
-/opt/homebrew/opt/gettext → ../Cellar/gettext/0.26
-/opt/homebrew/opt/glib → ../Cellar/glib/2.86.0
+/opt/homebrew/libexec/lima/limactl-mcp [6.6M]
+/opt/homebrew/libexec/lima/limactl-url-fedora-rawhide [1.3K]
+/opt/homebrew/opt/capstone → ../Cellar/capstone/5.0.8
+/opt/homebrew/opt/dtc → ../Cellar/dtc/1.8.0
+/opt/homebrew/opt/gettext → ../Cellar/gettext/1.0
+/opt/homebrew/opt/glib → ../Cellar/glib/2.88.1
 /opt/homebrew/opt/gmp → ../Cellar/gmp/6.3.0
-/opt/homebrew/opt/gnutls → ../Cellar/gnutls/3.8.10
-/opt/homebrew/opt/jpeg-turbo → ../Cellar/jpeg-turbo/3.1.2
+/opt/homebrew/opt/gnutls → ../Cellar/gnutls/3.8.13_2
+/opt/homebrew/opt/jpeg-turbo → ../Cellar/jpeg-turbo/3.1.4.1
 /opt/homebrew/opt/libidn2 → ../Cellar/libidn2/2.3.8
-/opt/homebrew/opt/libjpeg-turbo → ../Cellar/jpeg-turbo/3.1.2
-/opt/homebrew/opt/libnettle → ../Cellar/nettle/3.10.2
-/opt/homebrew/opt/libpng → ../Cellar/libpng/1.6.50
-/opt/homebrew/opt/libslirp → ../Cellar/libslirp/4.9.1
-/opt/homebrew/opt/libssh → ../Cellar/libssh/0.11.3
-/opt/homebrew/opt/libtasn → ../Cellar/libtasn1/4.20.0
-/opt/homebrew/opt/libtasn1 → ../Cellar/libtasn1/4.20.0
-/opt/homebrew/opt/libunistring → ../Cellar/libunistring/1.3
-/opt/homebrew/opt/libusb → ../Cellar/libusb/1.0.29
+/opt/homebrew/opt/libjpeg-turbo → ../Cellar/jpeg-turbo/3.1.4.1
+/opt/homebrew/opt/libnettle → ../Cellar/nettle/4.0
+/opt/homebrew/opt/libpng → ../Cellar/libpng/1.6.58
+/opt/homebrew/opt/libslirp → ../Cellar/libslirp/4.9.3
+/opt/homebrew/opt/libssh → ../Cellar/libssh/0.12.0_1
+/opt/homebrew/opt/libtasn → ../Cellar/libtasn1/4.21.0
+/opt/homebrew/opt/libtasn1 → ../Cellar/libtasn1/4.21.0
+/opt/homebrew/opt/libunistring → ../Cellar/libunistring/1.4.2
+/opt/homebrew/opt/libusb → ../Cellar/libusb/1.0.30
 /opt/homebrew/opt/lzo → ../Cellar/lzo/2.10
-/opt/homebrew/opt/ncurses → ../Cellar/ncurses/6.5
-/opt/homebrew/opt/nettle → ../Cellar/nettle/3.10.2
-/opt/homebrew/opt/openssl → ../Cellar/openssl@3/3.5.2
-/opt/homebrew/opt/openssl@3 → ../Cellar/openssl@3/3.5.2
-/opt/homebrew/opt/openssl@3.3 → ../Cellar/openssl@3/3.5.2
-/opt/homebrew/opt/openssl@3.5 → ../Cellar/openssl@3/3.5.2
-/opt/homebrew/opt/p11-kit → ../Cellar/p11-kit/0.25.8
-/opt/homebrew/opt/pcre2 → ../Cellar/pcre2/10.46
+/opt/homebrew/opt/ncurses → ../Cellar/ncurses/6.6
+/opt/homebrew/opt/nettle → ../Cellar/nettle/4.0
+/opt/homebrew/opt/nettle@4 → ../Cellar/nettle/4.0
+/opt/homebrew/opt/openssl → ../Cellar/openssl@3/3.6.2
+/opt/homebrew/opt/openssl@3 → ../Cellar/openssl@3/3.6.2
+/opt/homebrew/opt/openssl@3.6 → ../Cellar/openssl@3/3.6.2
+/opt/homebrew/opt/p11-kit → ../Cellar/p11-kit/0.26.2
+/opt/homebrew/opt/pcre2 → ../Cellar/pcre2/10.47_1
 /opt/homebrew/opt/pixman → ../Cellar/pixman/0.46.4
-/opt/homebrew/opt/pzstd → ../Cellar/zstd/1.5.7
-/opt/homebrew/opt/qemu → ../Cellar/qemu/10.1.0
+/opt/homebrew/opt/pzstd → ../Cellar/zstd/1.5.7_1
+/opt/homebrew/opt/qemu → ../Cellar/qemu/10.2.2
 /opt/homebrew/opt/snappy → ../Cellar/snappy/1.2.2
 /opt/homebrew/opt/vde → ../Cellar/vde/2.3.3
-/opt/homebrew/opt/zstd → ../Cellar/zstd/1.5.7
-/opt/homebrew/share/lima/lima-guestagent.Linux-aarch64.gz [12M]
-/opt/homebrew/share/lima/templates/_default/mounts.yaml [104B]
-/opt/homebrew/share/lima/templates/_images/fedora-42.yaml [592B]
+/opt/homebrew/opt/zstd → ../Cellar/zstd/1.5.7_1
+/opt/homebrew/share/lima/lima-guestagent.Linux-aarch64.gz [6.9M]
+/opt/homebrew/share/lima/templates/_default/mounts.yaml [171B]
+/opt/homebrew/share/lima/templates/_images/fedora-42.yaml [889B]
 /opt/homebrew/share/lima/templates/_images/ubuntu.yaml [2.4K]
-/opt/homebrew/share/qemu → ../Cellar/qemu/10.1.0/share/qemu
+/opt/homebrew/share/qemu → ../Cellar/qemu/10.2.2/share/qemu

--- a/deps-verification-x86.txt
+++ b/deps-verification-x86.txt
@@ -1,117 +1,116 @@
-/usr/local/libexec/lima/limactl-mcp [6.5M]
-/usr/local/libexec/lima/limactl-url-fedora-rawhide [1.3K]
-/usr/local/Cellar/qemu/10.2.0/share/qemu/vgabios-stdvga.bin [39K]
-/usr/local/Cellar/capstone/5.0.6/lib/libcapstone.5.dylib [6.9M]
-/usr/local/Cellar/capstone/5.0.6/lib/libcapstone.dylib → libcapstone.5.dylib
-/usr/local/Cellar/dtc/1.7.2/lib/libfdt.1.dylib → libfdt.dylib.1.7.2
-/usr/local/Cellar/dtc/1.7.2/lib/libfdt.dylib → libfdt.1.dylib
-/usr/local/Cellar/dtc/1.7.2/lib/libfdt.dylib.1.7.2 [54K]
-/usr/local/Cellar/gettext/0.26/lib/libintl.8.dylib [221K]
-/usr/local/Cellar/gettext/0.26/lib/libintl.dylib → libintl.8.dylib
-/usr/local/Cellar/glib/2.86.0/lib/libgio-2.0.0.dylib [1.7M]
-/usr/local/Cellar/glib/2.86.0/lib/libgio-2.0.dylib → libgio-2.0.0.dylib
-/usr/local/Cellar/glib/2.86.0/lib/libglib-2.0.0.dylib [1.1M]
-/usr/local/Cellar/glib/2.86.0/lib/libglib-2.0.dylib → libglib-2.0.0.dylib
-/usr/local/Cellar/glib/2.86.0/lib/libgmodule-2.0.0.dylib [51K]
-/usr/local/Cellar/glib/2.86.0/lib/libgmodule-2.0.dylib → libgmodule-2.0.0.dylib
-/usr/local/Cellar/glib/2.86.0/lib/libgobject-2.0.0.dylib [344K]
-/usr/local/Cellar/glib/2.86.0/lib/libgobject-2.0.dylib → libgobject-2.0.0.dylib
-/usr/local/Cellar/gmp/6.3.0/lib/libgmp.10.dylib [454K]
+/usr/local/Cellar/capstone/5.0.8/lib/libcapstone.5.dylib [6.8M]
+/usr/local/Cellar/capstone/5.0.8/lib/libcapstone.dylib → libcapstone.5.dylib
+/usr/local/Cellar/dtc/1.8.0/lib/libfdt.1.dylib [30K]
+/usr/local/Cellar/dtc/1.8.0/lib/libfdt.dylib → libfdt.1.dylib
+/usr/local/Cellar/gettext/1.0/lib/libintl.8.dylib [185K]
+/usr/local/Cellar/gettext/1.0/lib/libintl.dylib → libintl.8.dylib
+/usr/local/Cellar/glib/2.88.1/lib/libgio-2.0.0.dylib [1.6M]
+/usr/local/Cellar/glib/2.88.1/lib/libgio-2.0.dylib → libgio-2.0.0.dylib
+/usr/local/Cellar/glib/2.88.1/lib/libglib-2.0.0.dylib [1.1M]
+/usr/local/Cellar/glib/2.88.1/lib/libglib-2.0.dylib → libglib-2.0.0.dylib
+/usr/local/Cellar/glib/2.88.1/lib/libgmodule-2.0.0.dylib [23K]
+/usr/local/Cellar/glib/2.88.1/lib/libgmodule-2.0.dylib → libgmodule-2.0.0.dylib
+/usr/local/Cellar/glib/2.88.1/lib/libgobject-2.0.0.dylib [320K]
+/usr/local/Cellar/glib/2.88.1/lib/libgobject-2.0.dylib → libgobject-2.0.0.dylib
+/usr/local/Cellar/gmp/6.3.0/lib/libgmp.10.dylib [410K]
 /usr/local/Cellar/gmp/6.3.0/lib/libgmp.dylib → libgmp.10.dylib
-/usr/local/Cellar/gnutls/3.8.10/lib/libgnutls.30.dylib [1.9M]
-/usr/local/Cellar/gnutls/3.8.10/lib/libgnutls.dylib → libgnutls.30.dylib
-/usr/local/Cellar/jpeg-turbo/3.1.2/lib/libjpeg.8.3.2.dylib [680K]
-/usr/local/Cellar/jpeg-turbo/3.1.2/lib/libjpeg.8.dylib → libjpeg.8.3.2.dylib
-/usr/local/Cellar/jpeg-turbo/3.1.2/lib/libjpeg.dylib → libjpeg.8.dylib
-/usr/local/Cellar/libidn2/2.3.8/lib/libidn2.0.dylib [234K]
+/usr/local/Cellar/gnutls/3.8.13_2/lib/libgnutls.30.dylib [2.0M]
+/usr/local/Cellar/gnutls/3.8.13_2/lib/libgnutls.dylib → libgnutls.30.dylib
+/usr/local/Cellar/jpeg-turbo/3.1.4.1/lib/libjpeg.8.3.2.dylib [648K]
+/usr/local/Cellar/jpeg-turbo/3.1.4.1/lib/libjpeg.8.dylib → libjpeg.8.3.2.dylib
+/usr/local/Cellar/jpeg-turbo/3.1.4.1/lib/libjpeg.dylib → libjpeg.8.dylib
+/usr/local/Cellar/libidn2/2.3.8/lib/libidn2.0.dylib [206K]
 /usr/local/Cellar/libidn2/2.3.8/lib/libidn2.dylib → libidn2.0.dylib
-/usr/local/Cellar/libpng/1.6.50/lib/libpng.dylib → libpng16.dylib
-/usr/local/Cellar/libpng/1.6.50/lib/libpng16.16.dylib [185K]
-/usr/local/Cellar/libpng/1.6.50/lib/libpng16.dylib → libpng16.16.dylib
-/usr/local/Cellar/libslirp/4.9.1/lib/libslirp.0.dylib [146K]
-/usr/local/Cellar/libslirp/4.9.1/lib/libslirp.dylib → libslirp.0.dylib
-/usr/local/Cellar/libssh/0.12.0/lib/libssh.4.11.0.dylib [483K]
-/usr/local/Cellar/libssh/0.12.0/lib/libssh.4.dylib → libssh.4.11.0.dylib
-/usr/local/Cellar/libssh/0.12.0/lib/libssh.dylib → libssh.4.dylib
-/usr/local/Cellar/libtasn1/4.20.0/lib/libtasn1.6.dylib [103K]
-/usr/local/Cellar/libtasn1/4.20.0/lib/libtasn1.dylib → libtasn1.6.dylib
-/usr/local/Cellar/libunistring/1.3/lib/libunistring.5.dylib [1.9M]
-/usr/local/Cellar/libunistring/1.3/lib/libunistring.dylib → libunistring.5.dylib
-/usr/local/Cellar/libusb/1.0.29/lib/libusb-1.0.0.dylib [156K]
-/usr/local/Cellar/libusb/1.0.29/lib/libusb-1.0.dylib → libusb-1.0.0.dylib
-/usr/local/Cellar/lzo/2.10/lib/liblzo2.2.dylib [136K]
+/usr/local/Cellar/libpng/1.6.58/lib/libpng.dylib → libpng16.dylib
+/usr/local/Cellar/libpng/1.6.58/lib/libpng16.16.dylib [169K]
+/usr/local/Cellar/libpng/1.6.58/lib/libpng16.dylib → libpng16.16.dylib
+/usr/local/Cellar/libslirp/4.9.3/lib/libslirp.0.dylib [122K]
+/usr/local/Cellar/libslirp/4.9.3/lib/libslirp.dylib → libslirp.0.dylib
+/usr/local/Cellar/libssh/0.12.0_1/lib/libssh.4.11.0.dylib [483K]
+/usr/local/Cellar/libssh/0.12.0_1/lib/libssh.4.dylib → libssh.4.11.0.dylib
+/usr/local/Cellar/libssh/0.12.0_1/lib/libssh.dylib → libssh.4.dylib
+/usr/local/Cellar/libtasn1/4.21.0/lib/libtasn1.6.dylib [67K]
+/usr/local/Cellar/libtasn1/4.21.0/lib/libtasn1.dylib → libtasn1.6.dylib
+/usr/local/Cellar/libunistring/1.4.2/lib/libunistring.5.dylib [1.9M]
+/usr/local/Cellar/libunistring/1.4.2/lib/libunistring.dylib → libunistring.5.dylib
+/usr/local/Cellar/libusb/1.0.30/lib/libusb-1.0.0.dylib [125K]
+/usr/local/Cellar/libusb/1.0.30/lib/libusb-1.0.dylib → libusb-1.0.0.dylib
+/usr/local/Cellar/lzo/2.10/lib/liblzo2.2.dylib [121K]
 /usr/local/Cellar/lzo/2.10/lib/liblzo2.dylib → liblzo2.2.dylib
-/usr/local/Cellar/ncurses/6.5/lib/libcurses.dylib → libncurses.dylib
-/usr/local/Cellar/ncurses/6.5/lib/libncurses.6.dylib → libncursesw.6.dylib
-/usr/local/Cellar/ncurses/6.5/lib/libncurses.dylib → libncursesw.6.dylib
-/usr/local/Cellar/ncurses/6.5/lib/libncursesw.6.dylib [338K]
-/usr/local/Cellar/ncurses/6.5/lib/libncursesw.dylib → libncursesw.6.dylib
-/usr/local/Cellar/nettle/3.10.2/lib/libhogweed.6.11.dylib [273K]
-/usr/local/Cellar/nettle/3.10.2/lib/libhogweed.6.dylib → libhogweed.6.11.dylib
-/usr/local/Cellar/nettle/3.10.2/lib/libhogweed.dylib → libhogweed.6.11.dylib
-/usr/local/Cellar/nettle/3.10.2/lib/libnettle.8.11.dylib [309K]
-/usr/local/Cellar/nettle/3.10.2/lib/libnettle.8.dylib → libnettle.8.11.dylib
-/usr/local/Cellar/nettle/3.10.2/lib/libnettle.dylib → libnettle.8.11.dylib
-/usr/local/Cellar/openssl@3/3.5.2/lib/libcrypto.3.dylib [4.9M]
-/usr/local/Cellar/openssl@3/3.5.2/lib/libcrypto.dylib → libcrypto.3.dylib
-/usr/local/Cellar/p11-kit/0.25.8/lib/libp11-kit.0.dylib [1.2M]
-/usr/local/Cellar/p11-kit/0.25.8/lib/libp11-kit.dylib → libp11-kit.0.dylib
-/usr/local/Cellar/p11-kit/0.25.8/lib/p11-kit-proxy.dylib → libp11-kit.0.dylib
-/usr/local/Cellar/pcre2/10.46/lib/libpcre2-8.0.dylib [625K]
-/usr/local/Cellar/pcre2/10.46/lib/libpcre2-8.dylib → libpcre2-8.0.dylib
-/usr/local/Cellar/pixman/0.46.4/lib/libpixman-1.0.dylib [615K]
+/usr/local/Cellar/ncurses/6.6/lib/libcurses.dylib → libncurses.dylib
+/usr/local/Cellar/ncurses/6.6/lib/libncurses.6.dylib → libncursesw.6.dylib
+/usr/local/Cellar/ncurses/6.6/lib/libncurses.dylib → libncursesw.6.dylib
+/usr/local/Cellar/ncurses/6.6/lib/libncursesw.6.dylib [314K]
+/usr/local/Cellar/ncurses/6.6/lib/libncursesw.dylib → libncursesw.6.dylib
+/usr/local/Cellar/nettle/4.0/lib/libhogweed.7.0.dylib [255K]
+/usr/local/Cellar/nettle/4.0/lib/libhogweed.7.dylib → libhogweed.7.0.dylib
+/usr/local/Cellar/nettle/4.0/lib/libhogweed.dylib → libhogweed.7.0.dylib
+/usr/local/Cellar/nettle/4.0/lib/libnettle.9.0.dylib [293K]
+/usr/local/Cellar/nettle/4.0/lib/libnettle.9.dylib → libnettle.9.0.dylib
+/usr/local/Cellar/nettle/4.0/lib/libnettle.dylib → libnettle.9.0.dylib
+/usr/local/Cellar/openssl@3/3.6.2/lib/libcrypto.3.dylib [5.0M]
+/usr/local/Cellar/openssl@3/3.6.2/lib/libcrypto.dylib → libcrypto.3.dylib
+/usr/local/Cellar/p11-kit/0.26.2/lib/libp11-kit.0.dylib [1.4M]
+/usr/local/Cellar/p11-kit/0.26.2/lib/libp11-kit.dylib → libp11-kit.0.dylib
+/usr/local/Cellar/p11-kit/0.26.2/lib/p11-kit-proxy.dylib → libp11-kit.0.dylib
+/usr/local/Cellar/pcre2/10.47_1/lib/libpcre2-8.0.dylib [588K]
+/usr/local/Cellar/pcre2/10.47_1/lib/libpcre2-8.dylib → libpcre2-8.0.dylib
+/usr/local/Cellar/pixman/0.46.4/lib/libpixman-1.0.dylib [606K]
 /usr/local/Cellar/pixman/0.46.4/lib/libpixman-1.dylib → libpixman-1.0.dylib
-/usr/local/Cellar/qemu/10.1.0/bin
-/usr/local/Cellar/qemu/10.1.0/bin/qemu-img [1.9M]
-/usr/local/Cellar/qemu/10.1.0/bin/qemu-system-x86_64 [24M]
-/usr/local/Cellar/qemu/10.1.0/share/qemu/edk2-x86_64-code.fd [3.5M]
-/usr/local/Cellar/qemu/10.1.0/share/qemu/efi-virtio.rom [157K]
-/usr/local/Cellar/qemu/10.1.0/share/qemu/kvmvapic.bin [9.0K]
-/usr/local/Cellar/snappy/1.2.2/lib/libsnappy.1.2.2.dylib [59K]
+/usr/local/Cellar/qemu/10.2.2/bin [ec2-user]
+/usr/local/Cellar/qemu/10.2.2/bin/qemu-img [1.9M]
+/usr/local/Cellar/qemu/10.2.2/bin/qemu-system-x86_64 [24M]
+/usr/local/Cellar/qemu/10.2.2/share/qemu/edk2-x86_64-code.fd [3.5M]
+/usr/local/Cellar/qemu/10.2.2/share/qemu/efi-virtio.rom [157K]
+/usr/local/Cellar/qemu/10.2.2/share/qemu/kvmvapic.bin [9.0K]
+/usr/local/Cellar/qemu/10.2.2/share/qemu/vgabios-stdvga.bin [39K]
+/usr/local/Cellar/snappy/1.2.2/lib/libsnappy.1.2.2.dylib [39K]
 /usr/local/Cellar/snappy/1.2.2/lib/libsnappy.1.dylib → libsnappy.1.2.2.dylib
 /usr/local/Cellar/snappy/1.2.2/lib/libsnappy.dylib → libsnappy.1.dylib
 /usr/local/Cellar/vde/2.3.3/lib/libvdeplug.3.dylib [52K]
 /usr/local/Cellar/vde/2.3.3/lib/libvdeplug.dylib → libvdeplug.3.dylib
-/usr/local/Cellar/zstd/1.5.7/lib/libzstd.1.5.7.dylib [745K]
-/usr/local/Cellar/zstd/1.5.7/lib/libzstd.1.dylib → libzstd.1.5.7.dylib
-/usr/local/Cellar/zstd/1.5.7/lib/libzstd.dylib → libzstd.1.dylib
-/usr/local/bin/limactl [29M]
+/usr/local/Cellar/zstd/1.5.7_1/lib/libzstd.1.5.7.dylib [713K]
+/usr/local/Cellar/zstd/1.5.7_1/lib/libzstd.1.dylib → libzstd.1.5.7.dylib
+/usr/local/Cellar/zstd/1.5.7_1/lib/libzstd.dylib → libzstd.1.dylib
+/usr/local/bin/limactl [33M]
 /usr/local/bin/qemu-img [34B]
 /usr/local/bin/qemu-system-x86_64 [44B]
-/usr/local/opt/capstone → ../Cellar/capstone/5.0.6
-/usr/local/opt/dtc → ../Cellar/dtc/1.7.2
-/usr/local/opt/gettext → ../Cellar/gettext/0.26
-/usr/local/opt/glib → ../Cellar/glib/2.86.0
+/usr/local/libexec/lima/limactl-mcp [6.9M]
+/usr/local/libexec/lima/limactl-url-fedora-rawhide [1.3K]
+/usr/local/opt/capstone → ../Cellar/capstone/5.0.8
+/usr/local/opt/dtc → ../Cellar/dtc/1.8.0
+/usr/local/opt/gettext → ../Cellar/gettext/1.0
+/usr/local/opt/glib → ../Cellar/glib/2.88.1
 /usr/local/opt/gmp → ../Cellar/gmp/6.3.0
-/usr/local/opt/gnutls → ../Cellar/gnutls/3.8.10
-/usr/local/opt/jpeg-turbo → ../Cellar/jpeg-turbo/3.1.2
+/usr/local/opt/gnutls → ../Cellar/gnutls/3.8.13_2
+/usr/local/opt/jpeg-turbo → ../Cellar/jpeg-turbo/3.1.4.1
 /usr/local/opt/libidn2 → ../Cellar/libidn2/2.3.8
-/usr/local/opt/libjpeg-turbo → ../Cellar/jpeg-turbo/3.1.2
-/usr/local/opt/libnettle → ../Cellar/nettle/3.10.2
-/usr/local/opt/libpng → ../Cellar/libpng/1.6.50
-/usr/local/opt/libslirp → ../Cellar/libslirp/4.9.1
-/usr/local/opt/libssh → ../Cellar/libssh/0.11.3
-/usr/local/opt/libtasn → ../Cellar/libtasn1/4.20.0
-/usr/local/opt/libtasn1 → ../Cellar/libtasn1/4.20.0
-/usr/local/opt/libunistring → ../Cellar/libunistring/1.3
-/usr/local/opt/libusb → ../Cellar/libusb/1.0.29
+/usr/local/opt/libjpeg-turbo → ../Cellar/jpeg-turbo/3.1.4.1
+/usr/local/opt/libnettle → ../Cellar/nettle/4.0
+/usr/local/opt/libpng → ../Cellar/libpng/1.6.58
+/usr/local/opt/libslirp → ../Cellar/libslirp/4.9.3
+/usr/local/opt/libssh → ../Cellar/libssh/0.12.0_1
+/usr/local/opt/libtasn → ../Cellar/libtasn1/4.21.0
+/usr/local/opt/libtasn1 → ../Cellar/libtasn1/4.21.0
+/usr/local/opt/libunistring → ../Cellar/libunistring/1.4.2
+/usr/local/opt/libusb → ../Cellar/libusb/1.0.30
 /usr/local/opt/lzo → ../Cellar/lzo/2.10
-/usr/local/opt/ncurses → ../Cellar/ncurses/6.5
-/usr/local/opt/nettle → ../Cellar/nettle/3.10.2
-/usr/local/opt/openssl → ../Cellar/openssl@3/3.5.2
-/usr/local/opt/openssl@3 → ../Cellar/openssl@3/3.5.2
-/usr/local/opt/openssl@3.3 → ../Cellar/openssl@3/3.5.2
-/usr/local/opt/openssl@3.5 → ../Cellar/openssl@3/3.5.2
-/usr/local/opt/p11-kit → ../Cellar/p11-kit/0.25.8
-/usr/local/opt/pcre2 → ../Cellar/pcre2/10.46
+/usr/local/opt/ncurses → ../Cellar/ncurses/6.6
+/usr/local/opt/nettle → ../Cellar/nettle/4.0
+/usr/local/opt/nettle@4 → ../Cellar/nettle/4.0
+/usr/local/opt/openssl → ../Cellar/openssl@3/3.6.2
+/usr/local/opt/openssl@3 → ../Cellar/openssl@3/3.6.2
+/usr/local/opt/openssl@3.6 → ../Cellar/openssl@3/3.6.2
+/usr/local/opt/p11-kit → ../Cellar/p11-kit/0.26.2
+/usr/local/opt/pcre2 → ../Cellar/pcre2/10.47_1
 /usr/local/opt/pixman → ../Cellar/pixman/0.46.4
-/usr/local/opt/pzstd → ../Cellar/zstd/1.5.7
-/usr/local/opt/qemu → ../Cellar/qemu/10.1.0
+/usr/local/opt/pzstd → ../Cellar/zstd/1.5.7_1
+/usr/local/opt/qemu → ../Cellar/qemu/10.2.2
 /usr/local/opt/snappy → ../Cellar/snappy/1.2.2
 /usr/local/opt/vde → ../Cellar/vde/2.3.3
-/usr/local/opt/zstd → ../Cellar/zstd/1.5.7
-/usr/local/share/lima/lima-guestagent.Linux-x86_64.gz [13M]
-/usr/local/share/lima/templates/_default/mounts.yaml [104B]
-/usr/local/share/lima/templates/_images/fedora-42.yaml [592B]
+/usr/local/opt/zstd → ../Cellar/zstd/1.5.7_1
+/usr/local/share/lima/lima-guestagent.Linux-x86_64.gz [7.6M]
+/usr/local/share/lima/templates/_default/mounts.yaml [171B]
+/usr/local/share/lima/templates/_images/fedora-42.yaml [889B]
 /usr/local/share/lima/templates/_images/ubuntu.yaml [2.4K]
-/usr/local/share/qemu → ../Cellar/qemu/10.1.0/share/qemu
+/usr/local/share/qemu → ../Cellar/qemu/10.2.2/share/qemu


### PR DESCRIPTION
*Description of changes:*

The `build-lima-and-qemu` workflow has been failing due to a known `dtc 1.8.0` packaging issue that causes `Symbol not found: _fdt_setprop` when QEMU launches (https://discuss.cachyos.org/t/dtc-package-from-the-latest-update-broke-qemu/30354).

Changes:
1. **Build QEMU from source** instead of using pre-compiled Homebrew bottles, ensuring QEMU links against the actual system libraries regardless of bottle/dtc version mismatches.
2. **Reorder `brew upgrade` before QEMU install** so QEMU compiles against final dependency versions.
3. **Update `deps-verification` files** with current runner state (openssl 3.6.2, gnutls 3.8.13, libssh 0.12.0, qemu 10.2.2, nettle 4.0, etc.).
4. **New verification logic in `lima-and-qemu.py`** — the script now always writes a `.generated.txt` file with the current build's dependencies (regardless of pass/fail). If the committed verification file is missing, the build fails. If it exists but has structural changes (new/removed libraries), the build fails. Version-only mismatches are warnings and pass.
5. **New `update-verification-files` workflow job** — runs after every non-PR build (even on failure via `if: always()`). Downloads the `.generated.txt` artifacts from both arch builds and creates a single PR (branch `chore/update-deps-verification`) with the updated files for review.
6. **Add debug log output** (`ha.stderr.log`, `ha.stdout.log`, `serial.log`) on Lima VM boot failure to aid future troubleshooting.

**How the verification flow works going forward:**

Normal case (no dependency changes):
- Weekly build runs → verification passes → bundle produced → no PR created (nothing changed)

Minor version bump (e.g. openssl 3.6.2 → 3.6.3):
- Weekly build runs → verification passes (version mismatches are warnings only) → bundle produced → `update-verification-files` job creates a PR with the updated files → merge it to keep files current

Structural change (e.g. new library added, library removed, soname change):
- Weekly build runs → verification FAILS → bundle NOT produced → but `.generated.txt` is still uploaded → `update-verification-files` job creates a PR showing the diff → review and merge the PR → re-run the workflow → verification passes → bundle produced

*Testing done:* CI passes — QEMU builds from source, Lima boots successfully, bundle is produced, verification files are generated and uploaded as artifacts.

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
