### PR TITLE
chore: update tag fetching to exclude non final tags

### DIFF
--- a/.github/workflows/submodulesync.yaml
+++ b/.github/workflows/submodulesync.yaml
@@ -25,7 +25,7 @@ jobs:
           # pin submodule to a commit, https://github.com/lima-vm/lima/commit/bd7442e34ebdccb4945828a007b5d102781bea92
           # (cd src/lima && git checkout bd7442e34ebdccb4945828a007b5d102781bea92)
           (cd src/lima && git fetch --tags)
-          TAG=`cd src/lima && git describe --tags $(git rev-list --tags --max-count=1)`
+          TAG=`cd src/lima && git tag -l 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1`
           echo "Pulling changes from release: $TAG"
           (cd src/lima && git checkout $TAG)
           


### PR DESCRIPTION
Issue #, if available:
We should only update our dependencies with latest versions of tags, we should not update on beta/ rc tagged releases.

This PR adds a grep check and sorts the tags according to semver, so we get the correct tag when choosing the top matching value in git tag

*Description of changes:*


*Testing done:*


- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.