### PR TITLE
fix(ci): allow build-lima-and-qemu workflow to inherit secrets

### DIFF
--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -32,6 +32,7 @@ jobs:
       contents: write
       pull-requests: write
     uses: ./.github/workflows/build-lima-and-qemu.yaml
+    secrets: inherit
 
   update-lima-and-qemu-bundle:
     if: github.event_name != 'pull_request' && github.actor != 'dependabot[bot]'


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Fixes https://github.com/runfinch/finch-core/actions/runs/32181038481/job/95856605229.

*Testing done:*


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.