### PR TITLE
build(deps): rollback and pin lima to v2.1.2

### DIFF
--- a/.github/workflows/submodulesync.yaml
+++ b/.github/workflows/submodulesync.yaml
@@ -24,10 +24,10 @@ jobs:
           git submodule update --remote
           # pin submodule to a commit, https://github.com/lima-vm/lima/commit/bd7442e34ebdccb4945828a007b5d102781bea92
           # (cd src/lima && git checkout bd7442e34ebdccb4945828a007b5d102781bea92)
-          (cd src/lima && git fetch --tags)
-          TAG=`cd src/lima && git tag -l 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1`
-          echo "Pulling changes from release: $TAG"
-          (cd src/lima && git checkout $TAG)
+          # (cd src/lima && git fetch --tags)
+          # TAG=`cd src/lima && git tag -l 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1`
+          # echo "Pulling changes from release: $TAG"
+          # (cd src/lima && git checkout $TAG)
           
           # finch-daemon
           (cd src/finch-daemon && git fetch --tags)


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Lima v2.1.3+ seems to be causing issues with `finch vm init` on latest WSL2 versions. Rolling back to v2.1.2.

*Testing done:*


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.